### PR TITLE
fix: Ironsource improvements

### DIFF
--- a/client.go
+++ b/client.go
@@ -249,7 +249,7 @@ func request(ctx context.Context, accessToken string, method string, url string,
 			// this is a database error
 			return nil, fmt.Errorf("%s", string(body))
 		}
-		return nil, fmt.Errorf("request returned non ok status code: %d", resp.StatusCode)
+		return nil, fmt.Errorf("request returned non ok status code: %d, %s", resp.StatusCode, string(body))
 	}
 
 	return body, nil

--- a/client.go
+++ b/client.go
@@ -245,6 +245,10 @@ func request(ctx context.Context, accessToken string, method string, url string,
 		if err = checkErrorResponse(body); err != nil {
 			return nil, ConstructNestedError("request returned an error", err)
 		}
+		if resp.StatusCode == 500 {
+			// this is a database error
+			return nil, fmt.Errorf("%s", string(body))
+		}
 		return nil, fmt.Errorf("request returned non ok status code: %d", resp.StatusCode)
 	}
 

--- a/rows.go
+++ b/rows.go
@@ -165,6 +165,11 @@ func parseValue(columnType string, val interface{}) (driver.Value, error) {
 		suffix           = ")"
 	)
 
+	// No need to parse type if the value is nil
+	if val == nil {
+		return nil, nil
+	}
+
 	if strings.HasPrefix(columnType, arrayPrefix) && strings.HasSuffix(columnType, suffix) {
 		s := reflect.ValueOf(val)
 		res := make([]driver.Value, s.Len())
@@ -178,10 +183,6 @@ func parseValue(columnType string, val interface{}) (driver.Value, error) {
 	} else if strings.HasPrefix(columnType, decimalPrefix) && strings.HasSuffix(columnType, suffix) {
 		return parseSingleValue("Float64", val)
 	} else if strings.HasPrefix(columnType, nullablePrefix) && strings.HasSuffix(columnType, suffix) {
-		if val == nil {
-			return nil, nil
-		}
-
 		return parseSingleValue(columnType[len(nullablePrefix):len(columnType)-len(suffix)], val)
 	}
 

--- a/rows_test.go
+++ b/rows_test.go
@@ -32,7 +32,7 @@ func mockRows(isMultiStatement bool) driver.RowsNextResultSet {
 		"\"data\":[" +
 		"	[null,1,0.312321,123213.321321,\"text\", \"2080-12-31\",\"1989-04-15 01:02:03\",1,[1,2,3],[[]]]," +
 		"	[2,1,0.312321,123213.321321,\"text\",\"1970-01-01\",\"1970-01-01 00:00:00\",1,[1,2,3],[[]]]," +
-		"	[3,5,0.312321,123213.321321,\"text\",\"1970-01-01\",\"1970-01-01 00:00:00\",1,[5,2,3,2],[[\"TEST\",\"TEST1\"],[\"TEST3\"]]]]," +
+		"	[3,null,0.312321,123213.321321,\"text\",\"1970-01-01\",\"1970-01-01 00:00:00\",1,[5,2,3,2],[[\"TEST\",\"TEST1\"],[\"TEST3\"]]]]," +
 		"\"rows\":3," +
 		"\"statistics\":{" +
 		"	\"elapsed\":0.001797702," +
@@ -118,7 +118,7 @@ func TestRowsNext(t *testing.T) {
 	assert(err == nil, t, "Next shouldn't return an error")
 
 	assert(dest[0] == int32(3), t, "results not equal for int32")
-	assert(dest[1] == int64(5), t, "results not equal for int64")
+	assert(dest[1] == nil, t, "results not equal for int64")
 	assert(dest[2] == float32(0.312321), t, "results not equal for float32")
 	assert(dest[3] == float64(123213.321321), t, "results not equal for float64")
 	assert(dest[4] == "text", t, "results not equal for string")


### PR DESCRIPTION
Some improvements for ironsource poc:
1. Accept null values event if column type is not nullable
2. Propagate engine error messages to user (we currently just mention that we got 500)