### PR TITLE
feat: add token caching

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -15,10 +15,10 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.17.0'
+        go-version: '1.18.0'
     
     - name: Install goling
-      run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.2
+      run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.1
     
     - name: Install gocyclo
       run: go install github.com/fzipp/gocyclo/cmd/gocyclo@latest

--- a/.legitignore
+++ b/.legitignore
@@ -1,0 +1,1 @@
+instance_135B6BFBA9E6A8B4011E1875082F0541 # type: secret, commit: 41d2d4e, file: urls.go, line: 4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.3.0
     hooks:
       - id: check-merge-conflict
 

--- a/auth.go
+++ b/auth.go
@@ -24,7 +24,6 @@ func Authenticate(username, password, apiEndpoint string) (*Client, error) {
 	userAgent := ConstructUserAgentString()
 	cachedToken := getCachedAccessToken(username, apiEndpoint)
 	if len(cachedToken) > 0 {
-		infolog.Printf("Returning auth token from cache")
 		return &Client{Username: username, Password: password, ApiEndpoint: apiEndpoint, UserAgent: userAgent}, nil
 	} else {
 		values := map[string]string{"username": username, "password": password}

--- a/auth.go
+++ b/auth.go
@@ -48,12 +48,14 @@ func Authenticate(username, password, apiEndpoint string) (*Client, error) {
 	}
 }
 
+// getCacheKey calculates an access token key using the username and the apiEndpoint provided
 func getCacheKey(username, apiEndpoint string) string {
 	return username + apiEndpoint
 }
 
+// getCachedAccessToken returns a cached access token or empty when a token could not be found
 func getCachedAccessToken(username, apiEndpoint string) string {
-	cached := cache.Get(username + apiEndpoint)
+	cached := cache.Get(getCacheKey(username, apiEndpoint))
 	if cached != nil {
 		return cached.Value()
 	} else {

--- a/auth.go
+++ b/auth.go
@@ -3,6 +3,8 @@ package fireboltgosdk
 import (
 	"context"
 	"encoding/json"
+	"net/url"
+	"strings"
 )
 
 type AuthenticationResponse struct {
@@ -15,16 +17,21 @@ type AuthenticationResponse struct {
 
 // Authenticate sends an authentication request, and returns a newly constructed client object
 func Authenticate(username, password, apiEndpoint string) (*Client, error) {
-	infolog.Printf("Start authentication into '%s' using '%s'", apiEndpoint, LoginUrl)
-
-	values := map[string]string{"username": username, "password": password}
-	jsonData, err := json.Marshal(values)
-	if err != nil {
-		return nil, ConstructNestedError("error during json marshalling", err)
+	var loginUrl string
+	var contentType string
+	var body string
+	var err error
+	if strings.Contains(username, "@") {
+		loginUrl, contentType, body, err = prepareUsernamePasswordLogin(username, password)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		loginUrl, contentType, body = prepareServiceAccountLogin(username, password)
 	}
-
+	infolog.Printf("Start authentication into '%s' using '%s'", apiEndpoint, loginUrl)
 	userAgent := ConstructUserAgentString()
-	resp, err := request(context.TODO(), "", "POST", apiEndpoint+LoginUrl, userAgent, nil, string(jsonData))
+	resp, err := request(context.TODO(), "", "POST", apiEndpoint+loginUrl, userAgent, nil, body, contentType)
 	if err != nil {
 		return nil, ConstructNestedError("authentication request failed", err)
 	}
@@ -36,4 +43,28 @@ func Authenticate(username, password, apiEndpoint string) (*Client, error) {
 
 	infolog.Printf("Authentication was successful")
 	return &Client{AccessToken: authResp.AccessToken, ApiEndpoint: apiEndpoint, UserAgent: userAgent}, nil
+}
+
+func prepareUsernamePasswordLogin(username string, password string) (string, string, string, error) {
+	var authUrl = UsernamePasswordURLSuffix
+	//var values = map[string]string{"username": username, "password": password}
+	var contentType = "application/json"
+	values := map[string]string{"username": username, "password": password}
+	jsonData, err := json.Marshal(values)
+	if err != nil {
+		return "", "", "", ConstructNestedError("error during json marshalling", err)
+	} else {
+		return authUrl, contentType, string(jsonData), nil
+	}
+}
+
+func prepareServiceAccountLogin(username, password string) (string, string, string) {
+	var authUrl = ServiceAccountLoginURLSuffix
+	form := url.Values{}
+	form.Add("client_id", username)
+	form.Add("client_secret", password)
+	form.Add("grant_type", "client_credentials")
+	var contentType = "application/x-www-form-urlencoded"
+	var body = form.Encode()
+	return authUrl, contentType, body
 }

--- a/auth.go
+++ b/auth.go
@@ -3,10 +3,11 @@ package fireboltgosdk
 import (
 	"context"
 	"encoding/json"
-	"github.com/jellydator/ttlcache/v3"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/jellydator/ttlcache/v3"
 )
 
 type AuthenticationResponse struct {

--- a/auth_integration_test.go
+++ b/auth_integration_test.go
@@ -9,7 +9,7 @@ import (
 
 // TestAuthHappyPath tests normal authentication, and that the access token is actually set
 func TestAuthHappyPath(t *testing.T) {
-	if len(clientMock.AccessToken) == 0 {
+	if len(getCachedToken(clientMock.Username, clientMock.ApiEndpoint)) == 0 {
 		t.Errorf("Token is not set properly")
 	}
 }

--- a/auth_integration_test.go
+++ b/auth_integration_test.go
@@ -16,14 +16,14 @@ func TestAuthHappyPath(t *testing.T) {
 
 // TestAuthWrongCredential checks that authentication with wrong credentials returns an error
 func TestAuthWrongCredential(t *testing.T) {
-	if _, err := Authenticate(usernameMock, "wrong_password", GetHostNameURL()); err == nil {
+	if _, err := Authenticate("TestAuthWrongCredential", "wrong_password", GetHostNameURL()); err == nil {
 		t.Errorf("Authentication with wrong credentials didn't return an error")
 	}
 }
 
 // TestAuthEmptyCredential checks that authentication with empty password returns an error
 func TestAuthEmptyCredential(t *testing.T) {
-	if _, err := Authenticate(usernameMock, "", GetHostNameURL()); err == nil {
+	if _, err := Authenticate("TestAuthEmptyCredential", "", GetHostNameURL()); err == nil {
 		t.Errorf("Authentication with empty password didn't return an error")
 	}
 }

--- a/auth_integration_test.go
+++ b/auth_integration_test.go
@@ -9,7 +9,7 @@ import (
 
 // TestAuthHappyPath tests normal authentication, and that the access token is actually set
 func TestAuthHappyPath(t *testing.T) {
-	if len(getCachedToken(clientMock.Username, clientMock.ApiEndpoint)) == 0 {
+	if len(getCachedAccessToken(clientMock.Username, clientMock.ApiEndpoint)) == 0 {
 		t.Errorf("Token is not set properly")
 	}
 }

--- a/client.go
+++ b/client.go
@@ -12,7 +12,8 @@ import (
 )
 
 type Client struct {
-	AccessToken string
+	Username    string
+	Password    string
 	ApiEndpoint string
 	UserAgent   string
 }
@@ -26,7 +27,7 @@ func (c *Client) GetAccountIdByName(ctx context.Context, accountName string) (st
 
 	params := map[string]string{"account_name": accountName}
 
-	response, err := request(ctx, c.AccessToken, "GET", c.ApiEndpoint+AccountIdByNameURL, c.UserAgent, params, "", "")
+	response, err := c.request(ctx, "GET", c.ApiEndpoint+AccountIdByNameURL, c.UserAgent, params, "", "")
 	if err != nil {
 		return "", ConstructNestedError("error during getting account id by name request", err)
 	}
@@ -51,7 +52,7 @@ func (c *Client) GetEngineIdByName(ctx context.Context, engineName string, accou
 	}
 
 	params := map[string]string{"engine_name": engineName}
-	response, err := request(ctx, c.AccessToken, "GET", fmt.Sprintf(c.ApiEndpoint+EngineIdByNameURL, accountId), c.UserAgent, params, "", "")
+	response, err := c.request(ctx, "GET", fmt.Sprintf(c.ApiEndpoint+EngineIdByNameURL, accountId), c.UserAgent, params, "", "")
 	if err != nil {
 		return "", ConstructNestedError("error during getting engine id by name request", err)
 	}
@@ -74,7 +75,7 @@ func (c *Client) GetEngineUrlById(ctx context.Context, engineId string, accountI
 		Engine EngineResponse `json:"engine"`
 	}
 
-	response, err := request(ctx, c.AccessToken, "GET", fmt.Sprintf(c.ApiEndpoint+EngineByIdURL, accountId, engineId), c.UserAgent, make(map[string]string), "", "")
+	response, err := c.request(ctx, "GET", fmt.Sprintf(c.ApiEndpoint+EngineByIdURL, accountId, engineId), c.UserAgent, make(map[string]string), "", "")
 
 	if err != nil {
 		return "", ConstructNestedError("error during getting engine url by id request", err)
@@ -97,7 +98,7 @@ func (c *Client) GetDefaultAccountId(ctx context.Context) (string, error) {
 		Account AccountResponse `json:"account"`
 	}
 
-	response, err := request(ctx, c.AccessToken, "GET", fmt.Sprintf(c.ApiEndpoint+DefaultAccountURL), c.UserAgent, make(map[string]string), "", "")
+	response, err := c.request(ctx, "GET", fmt.Sprintf(c.ApiEndpoint+DefaultAccountURL), c.UserAgent, make(map[string]string), "", "")
 	if err != nil {
 		return "", ConstructNestedError("error during getting default account id request", err)
 	}
@@ -136,7 +137,7 @@ func (c *Client) GetEngineUrlByDatabase(ctx context.Context, databaseName string
 	}
 
 	params := map[string]string{"database_name": databaseName}
-	response, err := request(ctx, c.AccessToken, "GET", fmt.Sprintf(c.ApiEndpoint+EngineUrlByDatabaseNameURL, accountId), c.UserAgent, params, "", "")
+	response, err := c.request(ctx, "GET", fmt.Sprintf(c.ApiEndpoint+EngineUrlByDatabaseNameURL, accountId), c.UserAgent, params, "", "")
 	if err != nil {
 		return "", ConstructNestedError("error during getting engine url by database request", err)
 	}
@@ -157,7 +158,7 @@ func (c *Client) Query(ctx context.Context, engineUrl, databaseName, query strin
 		params[setKey] = setValue
 	}
 
-	response, err := request(ctx, c.AccessToken, "POST", engineUrl, c.UserAgent, params, query, "")
+	response, err := c.request(ctx, "POST", engineUrl, c.UserAgent, params, query, "")
 	if err != nil {
 		return nil, ConstructNestedError("error during query request", err)
 	}
@@ -209,7 +210,7 @@ func checkErrorResponse(response []byte) error {
 // additionally it passes the parameters and a bodyStr as a payload
 // if accessToken is passed, it is used for authorization
 // returns response and an error
-func request(ctx context.Context, accessToken string, method string, url string, userAgent string, params map[string]string, bodyStr string, contentType string) ([]byte, error) {
+func request(ctx context.Context, accessToken string, method string, url string, userAgent string, params map[string]string, bodyStr string, contentType string) ([]byte, error, int) {
 	req, _ := http.NewRequestWithContext(ctx, method, makeCanonicalUrl(url), strings.NewReader(bodyStr))
 
 	// adding sdk usage tracking
@@ -233,7 +234,7 @@ func request(ctx context.Context, accessToken string, method string, url string,
 	resp, err := client.Do(req)
 	if err != nil {
 		infolog.Println(err)
-		return nil, ConstructNestedError("error during a request execution", err)
+		return nil, ConstructNestedError("error during a request execution", err), 0
 	}
 
 	defer resp.Body.Close()
@@ -241,21 +242,21 @@ func request(ctx context.Context, accessToken string, method string, url string,
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		infolog.Println(err)
-		return nil, ConstructNestedError("error during reading a request response", err)
+		return nil, ConstructNestedError("error during reading a request response", err), 0
 	}
 
 	if !(resp.StatusCode >= 200 && resp.StatusCode < 300) {
 		if err = checkErrorResponse(body); err != nil {
-			return nil, ConstructNestedError("request returned an error", err)
+			return nil, ConstructNestedError("request returned an error", err), resp.StatusCode
 		}
 		if resp.StatusCode == 500 {
 			// this is a database error
-			return nil, fmt.Errorf("%s", string(body))
+			return nil, fmt.Errorf("%s", string(body)), resp.StatusCode
 		}
-		return nil, fmt.Errorf("request returned non ok status code: %d, %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("request returned non ok status code: %d, %s", resp.StatusCode, string(body)), resp.StatusCode
 	}
 
-	return body, nil
+	return body, nil, resp.StatusCode
 }
 
 // jsonStrictUnmarshall unmarshalls json into object, and returns an error
@@ -264,4 +265,25 @@ func jsonStrictUnmarshall(data []byte, v interface{}) error {
 	decoder := json.NewDecoder(bytes.NewReader(data))
 	decoder.DisallowUnknownFields()
 	return decoder.Decode(v)
+}
+
+func (c Client) request(ctx context.Context, method string, url string, userAgent string, params map[string]string, bodyStr string, contentType string) ([]byte, error) {
+	accessToken := getCachedToken(c.Username, c.ApiEndpoint)
+	var response []byte
+	var err error
+	var responseCode int
+	if len(accessToken) > 0 {
+		response, err, responseCode = request(ctx, accessToken, method, url, userAgent, params, bodyStr, contentType)
+	}
+	if len(accessToken) == 0 || (err == nil && responseCode == 401) {
+		DeleteTokenFromCache(c.Username, c.ApiEndpoint)
+		// Refreshing the access token as it is expired
+		_, err := Authenticate(c.Username, c.Password, GetHostNameURL())
+		if err != nil {
+			return nil, ConstructNestedError("error during refreshing access token", err)
+		}
+		accessToken := getCachedToken(c.Username, c.ApiEndpoint)
+		response, err, _ = request(ctx, accessToken, method, url, userAgent, params, bodyStr, contentType)
+	}
+	return response, err
 }

--- a/client.go
+++ b/client.go
@@ -26,7 +26,7 @@ func (c *Client) GetAccountIdByName(ctx context.Context, accountName string) (st
 
 	params := map[string]string{"account_name": accountName}
 
-	response, err := request(ctx, c.AccessToken, "GET", c.ApiEndpoint+AccountIdByNameURL, c.UserAgent, params, "")
+	response, err := request(ctx, c.AccessToken, "GET", c.ApiEndpoint+AccountIdByNameURL, c.UserAgent, params, "", "")
 	if err != nil {
 		return "", ConstructNestedError("error during getting account id by name request", err)
 	}
@@ -51,7 +51,7 @@ func (c *Client) GetEngineIdByName(ctx context.Context, engineName string, accou
 	}
 
 	params := map[string]string{"engine_name": engineName}
-	response, err := request(ctx, c.AccessToken, "GET", fmt.Sprintf(c.ApiEndpoint+EngineIdByNameURL, accountId), c.UserAgent, params, "")
+	response, err := request(ctx, c.AccessToken, "GET", fmt.Sprintf(c.ApiEndpoint+EngineIdByNameURL, accountId), c.UserAgent, params, "", "")
 	if err != nil {
 		return "", ConstructNestedError("error during getting engine id by name request", err)
 	}
@@ -74,7 +74,7 @@ func (c *Client) GetEngineUrlById(ctx context.Context, engineId string, accountI
 		Engine EngineResponse `json:"engine"`
 	}
 
-	response, err := request(ctx, c.AccessToken, "GET", fmt.Sprintf(c.ApiEndpoint+EngineByIdURL, accountId, engineId), c.UserAgent, make(map[string]string), "")
+	response, err := request(ctx, c.AccessToken, "GET", fmt.Sprintf(c.ApiEndpoint+EngineByIdURL, accountId, engineId), c.UserAgent, make(map[string]string), "", "")
 
 	if err != nil {
 		return "", ConstructNestedError("error during getting engine url by id request", err)
@@ -97,7 +97,7 @@ func (c *Client) GetDefaultAccountId(ctx context.Context) (string, error) {
 		Account AccountResponse `json:"account"`
 	}
 
-	response, err := request(ctx, c.AccessToken, "GET", fmt.Sprintf(c.ApiEndpoint+DefaultAccountURL), c.UserAgent, make(map[string]string), "")
+	response, err := request(ctx, c.AccessToken, "GET", fmt.Sprintf(c.ApiEndpoint+DefaultAccountURL), c.UserAgent, make(map[string]string), "", "")
 	if err != nil {
 		return "", ConstructNestedError("error during getting default account id request", err)
 	}
@@ -136,7 +136,7 @@ func (c *Client) GetEngineUrlByDatabase(ctx context.Context, databaseName string
 	}
 
 	params := map[string]string{"database_name": databaseName}
-	response, err := request(ctx, c.AccessToken, "GET", fmt.Sprintf(c.ApiEndpoint+EngineUrlByDatabaseNameURL, accountId), c.UserAgent, params, "")
+	response, err := request(ctx, c.AccessToken, "GET", fmt.Sprintf(c.ApiEndpoint+EngineUrlByDatabaseNameURL, accountId), c.UserAgent, params, "", "")
 	if err != nil {
 		return "", ConstructNestedError("error during getting engine url by database request", err)
 	}
@@ -157,7 +157,7 @@ func (c *Client) Query(ctx context.Context, engineUrl, databaseName, query strin
 		params[setKey] = setValue
 	}
 
-	response, err := request(ctx, c.AccessToken, "POST", engineUrl, c.UserAgent, params, query)
+	response, err := request(ctx, c.AccessToken, "POST", engineUrl, c.UserAgent, params, query, "")
 	if err != nil {
 		return nil, ConstructNestedError("error during query request", err)
 	}
@@ -209,7 +209,7 @@ func checkErrorResponse(response []byte) error {
 // additionally it passes the parameters and a bodyStr as a payload
 // if accessToken is passed, it is used for authorization
 // returns response and an error
-func request(ctx context.Context, accessToken string, method string, url string, userAgent string, params map[string]string, bodyStr string) ([]byte, error) {
+func request(ctx context.Context, accessToken string, method string, url string, userAgent string, params map[string]string, bodyStr string, contentType string) ([]byte, error) {
 	req, _ := http.NewRequestWithContext(ctx, method, makeCanonicalUrl(url), strings.NewReader(bodyStr))
 
 	// adding sdk usage tracking
@@ -218,6 +218,9 @@ func request(ctx context.Context, accessToken string, method string, url string,
 	if len(accessToken) > 0 {
 		var bearer = "Bearer " + accessToken
 		req.Header.Add("Authorization", bearer)
+	}
+	if len(contentType) > 0 {
+		req.Header.Set("Content-Type", contentType)
 	}
 
 	q := req.URL.Query()

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,123 @@
+package fireboltgosdk
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestCacheAccessToken(t *testing.T) {
+	var fetchTokenCount = 0
+	var totalCount = 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/auth/v1/login" {
+			fetchTokenCount++
+			_, _ = w.Write(getAuthResponse(10000))
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+		totalCount++
+	}))
+	defer server.Close()
+	t.Setenv("FIREBOLT_ENDPOINT", server.URL)
+	var client = &Client{Username: "username", Password: "password", ApiEndpoint: server.URL, UserAgent: "userAgent"}
+	var err error
+	for i := 0; i < 3; i++ {
+		_, err = client.request(context.TODO(), "GET", server.URL, "userAgent", nil, "")
+		if err != nil {
+			t.Errorf("Did not expect an error %s", err)
+		}
+	}
+	if fetchTokenCount != 1 {
+		t.Errorf("Did not fetch token only once. Total: %d", fetchTokenCount)
+	}
+
+	if totalCount != 4 {
+		t.Errorf("Expected to call the server 4 times (1x to fetch token and 3x to send another request). Total: %d", totalCount)
+	}
+
+	if getCachedAccessToken("username", server.URL) != "aMysteriousToken" {
+		t.Errorf("Did not fetch missing token")
+	}
+}
+
+func TestRefreshTokenOn401(t *testing.T) {
+	var fetchTokenCount = 0
+	var totalCount = 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/auth/v1/login" {
+			fetchTokenCount++
+			_, _ = w.Write(getAuthResponse(10000))
+		} else {
+			w.WriteHeader(http.StatusUnauthorized)
+		}
+		totalCount++
+	}))
+	defer server.Close()
+	t.Setenv("FIREBOLT_ENDPOINT", server.URL)
+	var client = &Client{Username: "username", Password: "password", ApiEndpoint: server.URL, UserAgent: "userAgent"}
+	_, _ = client.request(context.TODO(), "GET", server.URL, "userAgent", nil, "")
+	_, _ = client.request(context.TODO(), "GET", server.URL, "userAgent", nil, "")
+
+	if fetchTokenCount != 2 {
+		// The token should be fetched twice as it is removed from the cache during the second client.request() call
+		t.Errorf("Did not fetch token twice. Total: %d", fetchTokenCount)
+	}
+
+	if totalCount != 5 {
+		t.Errorf("Expected to call the server 5 times (2x to fetch tokens and 3x to send the request that returns a 403). Total: %d", totalCount)
+	}
+
+	if getCachedAccessToken("username", server.URL) != "aMysteriousToken" {
+		t.Errorf("Did not fetch missing token")
+	}
+
+}
+
+func TestFetchTokenWhenExpired(t *testing.T) {
+	var fetchTokenCount = 0
+	var totalCount = 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/auth/v1/login" {
+			fetchTokenCount++
+			_, _ = w.Write(getAuthResponse(1))
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+		totalCount++
+	}))
+	defer server.Close()
+	t.Setenv("FIREBOLT_ENDPOINT", server.URL)
+	var client = &Client{Username: "username", Password: "password", ApiEndpoint: server.URL, UserAgent: "userAgent"}
+	_, _ = client.request(context.TODO(), "GET", server.URL, "userAgent", nil, "")
+	// Waiting for the token to get expired
+	time.Sleep(2 * time.Millisecond)
+	_, _ = client.request(context.TODO(), "GET", server.URL, "userAgent", nil, "")
+
+	if fetchTokenCount != 2 {
+		// The token should be fetched twice as it is automatically removed from the cache because it is expired
+		t.Errorf("Did not fetch token twice. Total: %d", fetchTokenCount)
+	}
+
+	if totalCount != 4 {
+		t.Errorf("Expected to call the server 5 times (2x to fetch tokens and 3x to send the request that returns a 403). Total: %d", totalCount)
+	}
+
+	if getCachedAccessToken("username", server.URL) != "aMysteriousToken" {
+		t.Errorf("Did not fetch missing token")
+	}
+
+}
+func getAuthResponse(expiry int) []byte {
+	var response = `{
+   "access_token": "aMysteriousToken",
+   "refresh_token": "refresh",
+   "scope": "offline_access",
+   "expires_in": ` + strconv.Itoa(expiry) + `,
+   "token_type": "Bearer"
+}`
+	return []byte(response)
+}

--- a/client_test.go
+++ b/client_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 )
 
+// TestCacheAccessToken tests that a token is cached during authentication and reused for subsequent requests
 func TestCacheAccessToken(t *testing.T) {
 	var fetchTokenCount = 0
 	var totalCount = 0
@@ -44,6 +45,7 @@ func TestCacheAccessToken(t *testing.T) {
 	}
 }
 
+// TestRefreshTokenOn401 tests that a token is refreshed when the server returns a 401
 func TestRefreshTokenOn401(t *testing.T) {
 	var fetchTokenCount = 0
 	var totalCount = 0
@@ -77,6 +79,7 @@ func TestRefreshTokenOn401(t *testing.T) {
 
 }
 
+// TestFetchTokenWhenExpired tests that a new token is fetched upon expiry
 func TestFetchTokenWhenExpired(t *testing.T) {
 	var fetchTokenCount = 0
 	var totalCount = 0

--- a/connection_integration_test.go
+++ b/connection_integration_test.go
@@ -22,11 +22,6 @@ func TestConnectionSetStatement(t *testing.T) {
 	_, err = conn.QueryContext(context.TODO(), "SELECT * FROM information_schema.tables", nil)
 	assert(err == nil, t, "query returned an error, but shouldn't")
 
-	_, err = conn.ExecContext(context.TODO(), "SET use_standard_sql=0", nil)
-	assert(err == nil, t, "set use_standard_sql returned an error, but shouldn't")
-
-	_, err = conn.QueryContext(context.TODO(), "SELECT * FROM information_schema.tables", nil)
-	assert(err != nil, t, "query didn't return an error, but should")
 }
 
 // TestConnectionQuery checks simple SELECT 1 exec

--- a/go.mod
+++ b/go.mod
@@ -5,3 +5,7 @@ go 1.18
 require github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2
 
 require github.com/matishsiao/goInfo v0.0.0-20210923090445-da2e3fa8d45f
+
+require github.com/jellydator/ttlcache/v3 v3.0.0
+
+require golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,15 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/jellydator/ttlcache/v3 v3.0.0 h1:zmFhqrB/4sKiEiJHhtseJsNRE32IMVmJSs4++4gaQO4=
+github.com/jellydator/ttlcache/v3 v3.0.0/go.mod h1:WwTaEmcXQ3MTjOm4bsZoDFiCu/hMvNWLO1w67RXz6h4=
 github.com/matishsiao/goInfo v0.0.0-20210923090445-da2e3fa8d45f h1:B0OD7nYl2FPQEVrw8g2uyc1lGEzNbvrKh7fspGZcbvY=
 github.com/matishsiao/goInfo v0.0.0-20210923090445-da2e3fa8d45f/go.mod h1:aEt7p9Rvh67BYApmZwNDPpgircTO2kgdmDUoF/1QmwA=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2 h1:zzrxE1FKn5ryBNl9eKOeqQ58Y/Qpo3Q9QNxKHX5uzzQ=
 github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2/go.mod h1:hzfGeIUDq/j97IG+FhNqkowIyEcD88LrW6fyU3K3WqY=
+go.uber.org/goleak v1.1.10 h1:z+mqJhf6ss6BSfSM671tgKyZBFPTTJM+HLxnhPC3wu0=
+golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5 h1:2M3HP5CCK1Si9FQhwnzYhXdG6DXeebvUHFpre8QvbyI=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/tools v0.0.0-20210112230658-8b4aab62c064 h1:BmCFkEH4nJrYcAc2L08yX5RhYGD4j58PTMkEUDkpz2I=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=

--- a/urls.go
+++ b/urls.go
@@ -1,11 +1,10 @@
 package fireboltgosdk
 
 const (
-	UsernamePasswordURLSuffix    = "/auth/v1/login"
-	ServiceAccountLoginURLSuffix = "/auth/v1/token"
-	DefaultAccountURL            = "/iam/v2/account"
-	AccountIdByNameURL           = "/iam/v2/accounts:getIdByName"
-	EngineIdByNameURL            = "/core/v1/accounts/%s/engines:getIdByName"
-	EngineByIdURL                = "/core/v1/accounts/%s/engines/%s"
-	EngineUrlByDatabaseNameURL   = "/core/v1/accounts/%s/engines:getURLByDatabaseName"
+	LoginUrl                   = "/auth/v1/login"
+	DefaultAccountURL          = "/iam/v2/account"
+	AccountIdByNameURL         = "/iam/v2/accounts:getIdByName"
+	EngineIdByNameURL          = "/core/v1/accounts/%s/engines:getIdByName"
+	EngineByIdURL              = "/core/v1/accounts/%s/engines/%s"
+	EngineUrlByDatabaseNameURL = "/core/v1/accounts/%s/engines:getURLByDatabaseName"
 )

--- a/urls.go
+++ b/urls.go
@@ -1,10 +1,11 @@
 package fireboltgosdk
 
 const (
-	LoginUrl                   = "/auth/v1/login"
-	DefaultAccountURL          = "/iam/v2/account"
-	AccountIdByNameURL         = "/iam/v2/accounts:getIdByName"
-	EngineIdByNameURL          = "/core/v1/accounts/%s/engines:getIdByName"
-	EngineByIdURL              = "/core/v1/accounts/%s/engines/%s"
-	EngineUrlByDatabaseNameURL = "/core/v1/accounts/%s/engines:getURLByDatabaseName"
+	UsernamePasswordURLSuffix    = "/auth/v1/login"
+	ServiceAccountLoginURLSuffix = "/auth/v1/token"
+	DefaultAccountURL            = "/iam/v2/account"
+	AccountIdByNameURL           = "/iam/v2/accounts:getIdByName"
+	EngineIdByNameURL            = "/core/v1/accounts/%s/engines:getIdByName"
+	EngineByIdURL                = "/core/v1/accounts/%s/engines/%s"
+	EngineUrlByDatabaseNameURL   = "/core/v1/accounts/%s/engines:getURLByDatabaseName"
 )


### PR DESCRIPTION
The purpose of this PR is to add token caching for the GO SDK.
With this cache, newly created connections will reused an existing access token (when available), and fetch a new one if the token is not available. Also, a new token will be fetched upon expiry or when a 401 is returned by the server.

client_test.go was added in order to test the lifecycle of the tokens (when fetched, when they expired and when the server returns a 401)



