### PR TITLE
feat: add performance test (FIR-17551)

### DIFF
--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -34,6 +34,20 @@ jobs:
           api-endpoint: "api.dev.firebolt.io"
           region: "us-east-1"
           instance-type: "B2"
+      - name: Add data to database
+        env:
+          USER_NAME: ${{ secrets.FIREBOLT_USERNAME }}
+          PASSWORD: ${{ secrets.FIREBOLT_PASSWORD }}
+          DATABASE_NAME: ${{ steps.setup.outputs.database_name }}
+          ENGINE_NAME: ${{ steps.setup.outputs.engine_name }}
+          ENGINE_URL: ${{ steps.setup.outputs.engine_url }}
+          STOPPED_ENGINE_NAME: ${{ steps.setup.outputs.stopped_engine_name }}
+          STOPPED_ENGINE_URL: ${{ steps.setup.outputs.stopped_engine_url }}
+          FIREBOLT_ENDPOINT: "api.dev.firebolt.io"
+          ACCOUNT_NAME: "firebolt"
+        run: |
+          go run scripts/performance_test_init.go     
+
       - name: gobenchdata publish
         uses: bobheadxi/gobenchdata@v1
         with:

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -51,8 +51,8 @@ jobs:
       - name: gobenchdata publish
         uses: bobheadxi/gobenchdata@v1
         with:
-          PRUNE_COUNT: 10
-          GO_TEST_FLAGS: -test.benchtime=100x
+          PRUNE_COUNT: 15
+          GO_TEST_FLAGS: -test.benchtime=250x
           PUBLISH: true
           PUBLISH_BRANCH: gh-pages
           GO_BENCHMARKS: BenchmarkSelect

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       database:
-        description: 'Database (staging) - a new one will be created if not provided'
+        description: 'Database (dev) - a new one will be created if not provided'
         required: false
         default: ''
   workflow_call:
@@ -27,13 +27,14 @@ jobs:
           go-version: '1.18.0'
       - name: Setup database and engine
         id: setup
-        uses: aymeric-dispa/integration-testing-setup@master
+        uses: firebolt-db/integration-testing-setup@master
         with:
           firebolt-username: ${{ secrets.FIREBOLT_USERNAME }}
           firebolt-password: ${{ secrets.FIREBOLT_PASSWORD }}
           api-endpoint: "api.dev.firebolt.io"
           region: "us-east-1"
-          instance-type: "M4"
+          instance-type: "B4"
+          scale: 2
       - name: Add data to database
         env:
           USER_NAME: ${{ secrets.FIREBOLT_USERNAME }}

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -52,7 +52,7 @@ jobs:
         uses: bobheadxi/gobenchdata@v1
         with:
           PRUNE_COUNT: 15
-          GO_TEST_FLAGS: -test.benchtime=125x
+          GO_TEST_FLAGS: -test.benchtime=50x
           PUBLISH: true
           PUBLISH_BRANCH: gh-pages
           GO_BENCHMARKS: BenchmarkSelect

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -1,12 +1,7 @@
 name: Performance tests
 
-on:
-  workflow_dispatch:
-    inputs:
-      database:
-        description: 'Database (staging) - a new one will be created if not provided'
-        required: false
-        default: ''
+on: workflow_dispatch
+
 jobs:
   performance-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -22,16 +22,16 @@ jobs:
         id: setup
         uses: firebolt-db/integration-testing-setup@master
         with:
-          firebolt-username: ${{ secrets.FIREBOLT_USERNAME }}
-          firebolt-password: ${{ secrets.FIREBOLT_PASSWORD }}
+          firebolt-username: ${{ secrets.FIREBOLT_USERNAME_DEV }}
+          firebolt-password: ${{ secrets.FIREBOLT_PASSWORD_DEV }}
           api-endpoint: "api.dev.firebolt.io"
           region: "us-east-1"
-          instance-type: "B4"
+          instance-type: "C2"
           engine-scale: 2
       - name: Add data to database
         env:
-          USER_NAME: ${{ secrets.FIREBOLT_USERNAME }}
-          PASSWORD: ${{ secrets.FIREBOLT_PASSWORD }}
+          USER_NAME: ${{ secrets.FIREBOLT_USERNAME_DEV }}
+          PASSWORD: ${{ secrets.FIREBOLT_PASSWORD_DEV }}
           DATABASE_NAME: ${{ steps.setup.outputs.database_name }}
           ENGINE_NAME: ${{ steps.setup.outputs.engine_name }}
           ENGINE_URL: ${{ steps.setup.outputs.engine_url }}
@@ -52,8 +52,8 @@ jobs:
           GO_BENCHMARKS: BenchmarkSelect
           BENCHMARKS_OUT: benchmark/benchmarks.json
         env:
-           USER_NAME: ${{ secrets.FIREBOLT_USERNAME }}
-           PASSWORD: ${{ secrets.FIREBOLT_PASSWORD }}
+           USER_NAME: ${{ secrets.FIREBOLT_USERNAME_DEV }}
+           PASSWORD: ${{ secrets.FIREBOLT_PASSWORD_DEV }}
            DATABASE_NAME: ${{ steps.setup.outputs.database_name }}
            ENGINE_NAME: ${{ steps.setup.outputs.engine_name }}
            ENGINE_URL: ${{ steps.setup.outputs.engine_url }}

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -33,7 +33,7 @@ jobs:
           firebolt-password: ${{ secrets.FIREBOLT_PASSWORD }}
           api-endpoint: "api.dev.firebolt.io"
           region: "us-east-1"
-          instance-type: "B2"
+          instance-type: "M4"
       - name: Add data to database
         env:
           USER_NAME: ${{ secrets.FIREBOLT_USERNAME }}

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -38,7 +38,7 @@ jobs:
         uses: bobheadxi/gobenchdata@v1
         with:
           PRUNE_COUNT: 10
-          GO_TEST_FLAGS: -test.benchtime=10x
+          GO_TEST_FLAGS: -test.benchtime=100x
           PUBLISH: true
           PUBLISH_BRANCH: gh-pages
           GO_BENCHMARKS: BenchmarkSelect

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -8,19 +8,12 @@ on:
         description: 'Database (dev) - a new one will be created if not provided'
         required: false
         default: ''
-  workflow_call:
-    secrets:
-      FIREBOLT_USERNAME:
-        required: true
-      FIREBOLT_PASSWORD:
-        required: true
-
 jobs:
   performance-tests:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
@@ -34,7 +27,7 @@ jobs:
           api-endpoint: "api.dev.firebolt.io"
           region: "us-east-1"
           instance-type: "B4"
-          scale: 2
+          engine-scale: 2
       - name: Add data to database
         env:
           USER_NAME: ${{ secrets.FIREBOLT_USERNAME }}

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -1,11 +1,10 @@
 name: Performance tests
 
 on:
-  push:
   workflow_dispatch:
     inputs:
       database:
-        description: 'Database (dev) - a new one will be created if not provided'
+        description: 'Database (staging) - a new one will be created if not provided'
         required: false
         default: ''
 jobs:
@@ -22,22 +21,22 @@ jobs:
         id: setup
         uses: firebolt-db/integration-testing-setup@master
         with:
-          firebolt-username: ${{ secrets.FIREBOLT_USERNAME_DEV }}
-          firebolt-password: ${{ secrets.FIREBOLT_PASSWORD_DEV }}
-          api-endpoint: "api.dev.firebolt.io"
+          firebolt-username: ${{ secrets.FIREBOLT_USERNAME_STAGING }}
+          firebolt-password: ${{ secrets.FIREBOLT_PASSWORD_STAGING }}
+          api-endpoint: "api.staging.firebolt.io"
           region: "us-east-1"
           instance-type: "C2"
           engine-scale: 2
       - name: Add data to database
         env:
-          USER_NAME: ${{ secrets.FIREBOLT_USERNAME_DEV }}
-          PASSWORD: ${{ secrets.FIREBOLT_PASSWORD_DEV }}
+          USER_NAME: ${{ secrets.FIREBOLT_USERNAME_STAGING }}
+          PASSWORD: ${{ secrets.FIREBOLT_PASSWORD_STAGING }}
           DATABASE_NAME: ${{ steps.setup.outputs.database_name }}
           ENGINE_NAME: ${{ steps.setup.outputs.engine_name }}
           ENGINE_URL: ${{ steps.setup.outputs.engine_url }}
           STOPPED_ENGINE_NAME: ${{ steps.setup.outputs.stopped_engine_name }}
           STOPPED_ENGINE_URL: ${{ steps.setup.outputs.stopped_engine_url }}
-          FIREBOLT_ENDPOINT: "api.dev.firebolt.io"
+          FIREBOLT_ENDPOINT: "api.staging.firebolt.io"
           ACCOUNT_NAME: "firebolt"
         run: |
           go run scripts/performance_test_init.go     
@@ -52,14 +51,14 @@ jobs:
           GO_BENCHMARKS: BenchmarkSelect
           BENCHMARKS_OUT: benchmark/benchmarks.json
         env:
-           USER_NAME: ${{ secrets.FIREBOLT_USERNAME_DEV }}
-           PASSWORD: ${{ secrets.FIREBOLT_PASSWORD_DEV }}
+           USER_NAME: ${{ secrets.FIREBOLT_USERNAME_STAGING }}
+           PASSWORD: ${{ secrets.FIREBOLT_PASSWORD_STAGING }}
            DATABASE_NAME: ${{ steps.setup.outputs.database_name }}
            ENGINE_NAME: ${{ steps.setup.outputs.engine_name }}
            ENGINE_URL: ${{ steps.setup.outputs.engine_url }}
            STOPPED_ENGINE_NAME: ${{ steps.setup.outputs.stopped_engine_name }}
            STOPPED_ENGINE_URL: ${{ steps.setup.outputs.stopped_engine_url }}
-           FIREBOLT_ENDPOINT: "api.dev.firebolt.io"
+           FIREBOLT_ENDPOINT: "api.staging.firebolt.io"
            ACCOUNT_NAME: "firebolt"
            TEST_THREAD_COUNT: 5
            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -1,0 +1,56 @@
+name: Performance tests
+
+on:
+  push:
+  workflow_dispatch:
+    inputs:
+      database:
+        description: 'Database (staging) - a new one will be created if not provided'
+        required: false
+        default: ''
+  workflow_call:
+    secrets:
+      FIREBOLT_USERNAME:
+        required: true
+      FIREBOLT_PASSWORD:
+        required: true
+
+jobs:
+  performance-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.18.0'
+      - name: Setup database and engine
+        id: setup
+        uses: firebolt-db/integration-testing-setup@master
+        with:
+          firebolt-username: ${{ secrets.FIREBOLT_USERNAME }}
+          firebolt-password: ${{ secrets.FIREBOLT_PASSWORD }}
+          api-endpoint: "api.dev.firebolt.io"
+          region: "us-east-1"
+          instance-type: "B2"
+      - name: gobenchdata publish
+        uses: bobheadxi/gobenchdata@v1
+        with:
+          PRUNE_COUNT: 10
+          GO_TEST_FLAGS: -test.benchtime=10x
+          PUBLISH: true
+          PUBLISH_BRANCH: gh-pages
+          GO_BENCHMARKS: BenchmarkSelect
+        env:
+           USER_NAME: ${{ secrets.FIREBOLT_USERNAME }}
+           PASSWORD: ${{ secrets.FIREBOLT_PASSWORD }}
+           DATABASE_NAME: ${{ steps.setup.outputs.database_name }}
+           ENGINE_NAME: ${{ steps.setup.outputs.engine_name }}
+           ENGINE_URL: ${{ steps.setup.outputs.engine_url }}
+           STOPPED_ENGINE_NAME: ${{ steps.setup.outputs.stopped_engine_name }}
+           STOPPED_ENGINE_URL: ${{ steps.setup.outputs.stopped_engine_url }}
+           FIREBOLT_ENDPOINT: "api.dev.firebolt.io"
+           ACCOUNT_NAME: "firebolt"
+           TEST_THREAD_COUNT: 10
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -52,7 +52,7 @@ jobs:
         uses: bobheadxi/gobenchdata@v1
         with:
           PRUNE_COUNT: 15
-          GO_TEST_FLAGS: -test.benchtime=250x
+          GO_TEST_FLAGS: -test.benchtime=125x
           PUBLISH: true
           PUBLISH_BRANCH: gh-pages
           GO_BENCHMARKS: BenchmarkSelect

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -67,5 +67,5 @@ jobs:
            STOPPED_ENGINE_URL: ${{ steps.setup.outputs.stopped_engine_url }}
            FIREBOLT_ENDPOINT: "api.dev.firebolt.io"
            ACCOUNT_NAME: "firebolt"
-           TEST_THREAD_COUNT: 10
+           TEST_THREAD_COUNT: 5
            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -42,6 +42,7 @@ jobs:
           PUBLISH: true
           PUBLISH_BRANCH: gh-pages
           GO_BENCHMARKS: BenchmarkSelect
+          BENCHMARKS_OUT: benchmark/benchmarks.json
         env:
            USER_NAME: ${{ secrets.FIREBOLT_USERNAME }}
            PASSWORD: ${{ secrets.FIREBOLT_PASSWORD }}

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: '1.18.0'
+          
       - name: Setup database and engine
         id: setup
         uses: firebolt-db/integration-testing-setup@master
@@ -27,6 +28,7 @@ jobs:
           region: "us-east-1"
           instance-type: "C2"
           engine-scale: 2
+
       - name: Add data to database
         env:
           USER_NAME: ${{ secrets.FIREBOLT_USERNAME_STAGING }}
@@ -44,21 +46,21 @@ jobs:
       - name: gobenchdata publish
         uses: bobheadxi/gobenchdata@v1
         with:
-          PRUNE_COUNT: 15
+          PRUNE_COUNT: 20
           GO_TEST_FLAGS: -test.benchtime=50x
           PUBLISH: true
           PUBLISH_BRANCH: gh-pages
           GO_BENCHMARKS: BenchmarkSelect
           BENCHMARKS_OUT: benchmark/benchmarks.json
         env:
-           USER_NAME: ${{ secrets.FIREBOLT_USERNAME_STAGING }}
-           PASSWORD: ${{ secrets.FIREBOLT_PASSWORD_STAGING }}
-           DATABASE_NAME: ${{ steps.setup.outputs.database_name }}
-           ENGINE_NAME: ${{ steps.setup.outputs.engine_name }}
-           ENGINE_URL: ${{ steps.setup.outputs.engine_url }}
-           STOPPED_ENGINE_NAME: ${{ steps.setup.outputs.stopped_engine_name }}
-           STOPPED_ENGINE_URL: ${{ steps.setup.outputs.stopped_engine_url }}
-           FIREBOLT_ENDPOINT: "api.staging.firebolt.io"
-           ACCOUNT_NAME: "firebolt"
-           TEST_THREAD_COUNT: 5
-           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          USER_NAME: ${{ secrets.FIREBOLT_USERNAME_STAGING }}
+          PASSWORD: ${{ secrets.FIREBOLT_PASSWORD_STAGING }}
+          DATABASE_NAME: ${{ steps.setup.outputs.database_name }}
+          ENGINE_NAME: ${{ steps.setup.outputs.engine_name }}
+          ENGINE_URL: ${{ steps.setup.outputs.engine_url }}
+          STOPPED_ENGINE_NAME: ${{ steps.setup.outputs.stopped_engine_name }}
+          STOPPED_ENGINE_URL: ${{ steps.setup.outputs.stopped_engine_url }}
+          FIREBOLT_ENDPOINT: "api.staging.firebolt.io"
+          ACCOUNT_NAME: "firebolt"
+          TEST_THREAD_COUNT: 5
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -27,7 +27,7 @@ jobs:
           go-version: '1.18.0'
       - name: Setup database and engine
         id: setup
-        uses: firebolt-db/integration-testing-setup@master
+        uses: aymeric-dispa/integration-testing-setup@master
         with:
           firebolt-username: ${{ secrets.FIREBOLT_USERNAME }}
           firebolt-password: ${{ secrets.FIREBOLT_PASSWORD }}

--- a/performance_test.go
+++ b/performance_test.go
@@ -23,7 +23,6 @@ func TestMain(m *testing.M) {
 	threadCount, _ = strconv.Atoi(os.Getenv("TEST_THREAD_COUNT"))
 	dsn := fmt.Sprintf("firebolt://%s:%s@%s", username, password, databaseName)
 	var err error
-	// creating the connection pool
 	pool, err = sql.Open("firebolt", dsn)
 	defer pool.Close()
 

--- a/performance_test.go
+++ b/performance_test.go
@@ -23,12 +23,15 @@ func TestMain(m *testing.M) {
 	dsn := fmt.Sprintf("firebolt://%s:%s@%s", username, password, databaseName)
 	var err error
 	pool, err = sql.Open("firebolt", dsn)
-	defer pool.Close()
 
 	if err != nil {
 		log.Fatal("error during opening a driver", err)
 	}
 	code := m.Run()
+	err = pool.Close()
+	if err != nil {
+		return
+	}
 	os.Exit(code)
 }
 

--- a/performance_test.go
+++ b/performance_test.go
@@ -16,7 +16,6 @@ var selectLineItemQuery = "select * from lineitem ORDER BY l_orderkey LIMIT 1000
 var select1Query = "select 1;"
 
 func TestMain(m *testing.M) {
-	// constructing a dsn string, you need to set your credentials
 	username := os.Getenv("USER_NAME")
 	password := os.Getenv("PASSWORD")
 	databaseName := os.Getenv("DATABASE_NAME")
@@ -74,7 +73,7 @@ func executeQuery(loops int, query string, b *testing.B) {
 			b.Errorf("error during select query %v", err)
 		}
 
-		//Because the function is used for different queries, we only know the number of columns at runtime.
+		// because the function is used for different queries, we only know the number of columns at runtime.
 		columns, err = rows.Columns()
 		if err != nil {
 			b.Errorf("error while getting columns %v", err)

--- a/performance_test.go
+++ b/performance_test.go
@@ -96,12 +96,12 @@ func executeQuery(loops int, query string, b *testing.B) {
 		}
 
 		// iterating over the resulting rows
-		defer rows.Close()
 		for rows.Next() {
 			if err := rows.Scan(valuePointers...); err != nil {
 				b.Errorf("error during scan: %s", err)
 			}
 		}
+		rows.Close()
 	}
 
 }

--- a/performance_test.go
+++ b/performance_test.go
@@ -1,0 +1,84 @@
+package fireboltgosdk
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+var pool *sql.DB
+var threadCount int
+
+type atomicCounter int32
+
+func (c *atomicCounter) inc() int32 {
+	return atomic.AddInt32((*int32)(c), 1)
+}
+
+func (c *atomicCounter) get() int32 {
+	return atomic.LoadInt32((*int32)(c))
+}
+
+func TestMain(m *testing.M) {
+	// constructing a dsn string, you need to set your credentials
+	username := os.Getenv("USER_NAME")
+	password := os.Getenv("PASSWORD")
+	databaseName := os.Getenv("DATABASE_NAME")
+	threadCount, _ = strconv.Atoi(os.Getenv("TEST_THREAD_COUNT"))
+	dsn := fmt.Sprintf("firebolt://%s:%s@%s", username, password, databaseName)
+	var err error
+	// creating the connection pool
+	pool, err = sql.Open("firebolt", dsn)
+
+	if err != nil {
+		fmt.Println("error during opening a driver", err)
+	}
+	code := m.Run()
+	pool.Close()
+	os.Exit(code)
+}
+
+func BenchmarkSelectWithThreads(b *testing.B) {
+	var counter atomicCounter
+	var total = int32(b.N)
+	var wg sync.WaitGroup
+	wg.Add(threadCount)
+	for j := 0; j < threadCount; j++ {
+		go func(i int) {
+			for counter.get() < total {
+				counter.inc()
+				executeSelect(1)
+			}
+			defer wg.Done()
+		}(j)
+	}
+	wg.Wait()
+}
+
+func BenchmarkSelectWithoutThreads(b *testing.B) {
+	executeSelect(b.N)
+}
+
+func executeSelect(count int) {
+	for i := 0; i < count; i++ {
+		rows, err := pool.Query("SELECT 1")
+
+		if err != nil {
+			fmt.Println("error during select query: ", err)
+		}
+
+		// iterating over the resulting rows
+		defer rows.Close()
+		for rows.Next() {
+			var id int
+			if err := rows.Scan(&id); err != nil {
+				fmt.Println("error during scan: ", err)
+			}
+		}
+	}
+
+}

--- a/scripts/performance_test_init.go
+++ b/scripts/performance_test_init.go
@@ -3,7 +3,6 @@ package main
 import (
 	"database/sql"
 	"fmt"
-	_ "github.com/firebolt-db/firebolt-go-sdk"
 	"log"
 	"os"
 )
@@ -17,7 +16,7 @@ func main() {
 	db, err := sql.Open("firebolt", dsn)
 
 	if err != nil {
-		log.Fatal("error while opening a driver", err)
+		log.Fatal("error while opening a database", err)
 	}
 	queries := []string{
 		"CREATE EXTERNAL TABLE IF NOT EXISTS ex_lineitem ( l_orderkey LONG, l_partkey LONG, l_suppkey LONG, l_linenumber INT, l_quantity LONG, l_extendedprice LONG, l_discount LONG, l_tax LONG, l_returnflag TEXT, l_linestatus TEXT, l_shipdate TEXT, l_commitdate TEXT, l_receiptdate TEXT, l_shipinstruct TEXT, l_shipmode TEXT, l_comment TEXT)URL = 's3://firebolt-publishing-public/samples/tpc-h/parquet/lineitem/'OBJECT_PATTERN = '*.parquet'TYPE = (PARQUET)",
@@ -30,5 +29,9 @@ func main() {
 			log.Fatalf("the query %s returned an error: %v", query, err)
 		}
 	}
-	db.Close()
+	err = db.Close()
+	if err != nil {
+		log.Fatal("error while closing the database", err)
+	}
+
 }

--- a/scripts/performance_test_init.go
+++ b/scripts/performance_test_init.go
@@ -14,7 +14,6 @@ func main() {
 	databaseName := os.Getenv("DATABASE_NAME")
 	dsn := fmt.Sprintf("firebolt://%s:%s@%s", username, password, databaseName)
 
-	// creating the connection pool
 	db, err := sql.Open("firebolt", dsn)
 
 	if err != nil {
@@ -31,4 +30,5 @@ func main() {
 			log.Fatalf("the query %s returned an error: %v", query, err)
 		}
 	}
+	db.Close()
 }

--- a/scripts/performance_test_init.go
+++ b/scripts/performance_test_init.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	_ "github.com/firebolt-db/firebolt-go-sdk"
+	"log"
+	"os"
+)
+
+func main() {
+	username := os.Getenv("USER_NAME")
+	password := os.Getenv("PASSWORD")
+	databaseName := os.Getenv("DATABASE_NAME")
+	dsn := fmt.Sprintf("firebolt://%s:%s@%s", username, password, databaseName)
+
+	// creating the connection pool
+	db, err := sql.Open("firebolt", dsn)
+
+	if err != nil {
+		log.Fatal("error while opening a driver", err)
+	}
+	queries := []string{
+		"CREATE EXTERNAL TABLE IF NOT EXISTS ex_lineitem ( l_orderkey LONG, l_partkey LONG, l_suppkey LONG, l_linenumber INT, l_quantity LONG, l_extendedprice LONG, l_discount LONG, l_tax LONG, l_returnflag TEXT, l_linestatus TEXT, l_shipdate TEXT, l_commitdate TEXT, l_receiptdate TEXT, l_shipinstruct TEXT, l_shipmode TEXT, l_comment TEXT)URL = 's3://firebolt-publishing-public/samples/tpc-h/parquet/lineitem/'OBJECT_PATTERN = '*.parquet'TYPE = (PARQUET)",
+		"CREATE FACT TABLE IF NOT EXISTS lineitem ( l_orderkey LONG, l_partkey LONG, l_suppkey LONG, l_linenumber INT, l_quantity LONG, l_extendedprice LONG, l_discount LONG, l_tax LONG, l_returnflag TEXT, l_linestatus TEXT, l_shipdate TEXT, l_commitdate TEXT, l_receiptdate TEXT, l_shipinstruct TEXT, l_shipmode TEXT, l_comment TEXT ) PRIMARY INDEX l_orderkey, l_linenumber",
+		"INSERT INTO lineitem SELECT * FROM ex_lineitem"}
+
+	for _, query := range queries {
+		_, err := db.Query(query)
+		if err != nil {
+			log.Fatalf("the query %s returned an error: %v\n", query, err)
+		}
+	}
+}

--- a/scripts/performance_test_init.go
+++ b/scripts/performance_test_init.go
@@ -28,7 +28,7 @@ func main() {
 	for _, query := range queries {
 		_, err := db.Query(query)
 		if err != nil {
-			log.Fatalf("the query %s returned an error: %v\n", query, err)
+			log.Fatalf("the query %s returned an error: %v", query, err)
 		}
 	}
 }


### PR DESCRIPTION
What it does:
- Add performance tests using gobenchdata
    - There are two series of tests (one with SELECT 1; and another one using the lineitem table). Each test is executed with 1 and 5 threads.
    - All the results are stored in the branch gh-pages
 - Tests results can be found at https://docs.firebolt.io/firebolt-go-sdk/benchmark/
