### PR TITLE
ci: New slack notification action

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -77,3 +77,14 @@ jobs:
           label: Coverage
           message: ${{steps.coverage.outputs.covered}}%
           color: ${{steps.coverage.outputs.colour}}
+  
+      - name: Slack Notify of failure
+        if: failure()
+        id: slack
+        uses: firebolt-db/action-slack-nightly-notify@v1
+        with:
+          os: ${{ matrix.os }}
+          programming-language: GO
+          language-version: ${{ matrix.go-version }}
+          notifications-channel: 'ecosystem-ci-notifications'
+          slack-api-key: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
Improving our slack reporting app by migrating to an action implemented in JS. This allows it to run on all platforms, thus reporting all the failures in nightlies we might get. Also, adding some better info to see what failed at a glance.