### PR TITLE
test: fix system engine timeouts

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -93,4 +93,4 @@ jobs:
           SERVICE_ACCOUNT_CLIENT_ID: ${{ env.CLIENT_ID }}
           SERVICE_ACCOUNT_CLIENT_SECRET: ${{ env.CLIENT_SECRET }}
         run: |
-          go test . -v --tags=integration
+          go test . -timeout=30m -v --tags=integration

--- a/.github/workflows/nightly-v0.yml
+++ b/.github/workflows/nightly-v0.yml
@@ -59,7 +59,7 @@ jobs:
           SERVICE_ACCOUNT_CLIENT_ID: ${{ secrets.FIREBOLT_CLIENT_ID_STAGING }}
           SERVICE_ACCOUNT_CLIENT_SECRET: ${{ secrets.FIREBOLT_CLIENT_SECRET_STAGING }}
         run: |
-          go test . -v -coverprofile cover.out --tags=integration
+          go test . -timeout=30m -v -coverprofile cover.out --tags=integration
 
       - name: Print coverage percent
         id: coverage

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,7 +55,7 @@ jobs:
           SERVICE_ACCOUNT_CLIENT_ID: ${{ secrets.FIREBOLT_CLIENT_ID_STAGING }}
           SERVICE_ACCOUNT_CLIENT_SECRET: ${{ secrets.FIREBOLT_CLIENT_SECRET_STAGING }}
         run: |
-          go test . -v -coverprofile cover.out --tags=integration
+          go test .  -timeout=30m -v -coverprofile cover.out --tags=integration
 
       - name: Extract coverage percent
         id: coverage


### PR DESCRIPTION
Fixing the timeouts we're getting with the system engine tests. They take ~12min in other repos, GO has default timeout of 10m.