### PR TITLE
fix: remove dynamic/query suffix

### DIFF
--- a/client.go
+++ b/client.go
@@ -30,7 +30,7 @@ WHERE engine_name='%s'
 func (c *Client) GetEngineUrlStatusDBByName(ctx context.Context, engineName string, systemEngineUrl string) (string, string, string, error) {
 	infolog.Printf("Get info for engine '%s'", engineName)
 	engineSQL := fmt.Sprintf(engineInfoSQL, engineName)
-	queryRes, err := c.Query(ctx, systemEngineUrl+QueryUrl, "", engineSQL, make(map[string]string))
+	queryRes, err := c.Query(ctx, systemEngineUrl, "", engineSQL, make(map[string]string))
 	if err != nil {
 		return "", "", "", ConstructNestedError("error executing engine info sql query", err)
 	}

--- a/driver.go
+++ b/driver.go
@@ -53,7 +53,7 @@ func (d FireboltDriver) Open(dsn string) (driver.Conn, error) {
 		d.client.ConnectedToSystemEngine = true
 		if len(settings.engine) == 0 {
 			infolog.Println("Connected to a system engine")
-			d.engineUrl = systemEngineURL + QueryUrl
+			d.engineUrl = systemEngineURL
 			d.databaseName = settings.database
 		} else {
 			engineUrl, status, dbName, err := d.client.GetEngineUrlStatusDBByName(context.TODO(), settings.engine, systemEngineURL)

--- a/urls.go
+++ b/urls.go
@@ -4,5 +4,4 @@ const (
 	ServiceAccountLoginURLSuffix = "/oauth/token"
 	EngineUrlByAccountName       = "/web/v3/account/%s/engineUrl"
 	AccountIdByAccountName       = "/web/v3/account/%s/resolve"
-	QueryUrl                     = "/dynamic/query"
 )


### PR DESCRIPTION
Removed `dynamic/query` suffix from system engine query execution