### PR TITLE
fix: Carry on executing when UA string gen fails

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -15,6 +15,8 @@ import (
 	"github.com/xwb1989/sqlparser"
 )
 
+var goInfoFunc = goInfo.GetInfo
+
 func ConstructNestedError(message string, err error) error {
 	infolog.Printf("%s: %v", message, err)
 	return fmt.Errorf("%s: %v", message, err)
@@ -143,7 +145,7 @@ func ConstructUserAgentString() (ua_string string) {
 		}
 	}()
 	osNameVersion := runtime.GOOS
-	if gi, err := goInfo.GetInfo(); err == nil {
+	if gi, err := goInfoFunc(); err == nil {
 		osNameVersion += " " + gi.Core
 	}
 

--- a/utils.go
+++ b/utils.go
@@ -135,9 +135,11 @@ func GetHostNameURL() string {
 // and they will be concatenated with the final user-agent string
 func ConstructUserAgentString() (ua_string string) {
 	defer func() {
+		// This is a non-essential function, used for statistic gathering
+		// so carry on working if a failure occurs
 		if err := recover(); err != nil {
 			infolog.Printf("Unable to generate User Agent string")
-			ua_string = ""
+			ua_string = "GoSDK"
 		}
 	}()
 	osNameVersion := runtime.GOOS

--- a/utils.go
+++ b/utils.go
@@ -133,7 +133,13 @@ func GetHostNameURL() string {
 // ConstructUserAgentString returns a string with go, GoSDK and os type and versions
 // additionally user can set "FIREBOLT_GO_DRIVERS" and "FIREBOLT_GO_CLIENTS" env variable,
 // and they will be concatenated with the final user-agent string
-func ConstructUserAgentString() string {
+func ConstructUserAgentString() (ua_string string) {
+	defer func() {
+		if err := recover(); err != nil {
+			infolog.Printf("Unable to generate User Agent string")
+			ua_string = ""
+		}
+	}()
 	osNameVersion := runtime.GOOS
 	if gi, err := goInfo.GetInfo(); err == nil {
 		osNameVersion += " " + gi.Core
@@ -150,7 +156,8 @@ func ConstructUserAgentString() string {
 		goClients = ""
 	}
 
-	return strings.TrimSpace(fmt.Sprintf("%s GoSDK/%s (Go %s; %s) %s", goClients, sdkVersion, runtime.Version(), osNameVersion, goDrivers))
+	ua_string = strings.TrimSpace(fmt.Sprintf("%s GoSDK/%s (Go %s; %s) %s", goClients, sdkVersion, runtime.Version(), osNameVersion, goDrivers))
+	return ua_string
 }
 
 func valueToNamedValue(args []driver.Value) []driver.NamedValue {

--- a/utils_test.go
+++ b/utils_test.go
@@ -154,7 +154,7 @@ func TestConstructUserAgentStringFails(t *testing.T) {
 	}
 	userAgentString := ConstructUserAgentString()
 
-	if !(userAgentString == "GoSDK") {
+	if userAgentString != "GoSDK" {
 		t.Errorf("UserAgent string was not generated correctly")
 	}
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/matishsiao/goInfo"
 )
 
 func runParseSetStatementSuccess(t *testing.T, value, expectedKey, expectedValue string) {
@@ -138,6 +140,23 @@ func TestConstructUserAgentString(t *testing.T) {
 
 	os.Unsetenv("FIREBOLT_GO_DRIVERS")
 	os.Unsetenv("FIREBOLT_GO_CLIENTS")
+}
+
+// FIR-25705
+func TestConstructUserAgentStringFails(t *testing.T) {
+	// Save current function and restore at the end
+	old := goInfoFunc
+	defer func() { goInfoFunc = old }()
+
+	goInfoFunc = func() (goInfo.GoInfoObject, error) {
+		// Simulate goinfo failing
+		panic("Aaaaaaaaaa")
+	}
+	userAgentString := ConstructUserAgentString()
+
+	if !(userAgentString == "GoSDK") {
+		t.Errorf("UserAgent string was not generated correctly")
+	}
 }
 
 func runSplitStatement(t *testing.T, value string, expected []string) {


### PR DESCRIPTION
UserAgent string is used for statistics gathering only. Some customers reported issues with it in Docker. This allows the code to carry on with the execution.