### PR TITLE
feat: Use regex parsing for dsn

### DIFF
--- a/dsn.go
+++ b/dsn.go
@@ -1,8 +1,9 @@
 package fireboltgosdk
 
 import (
+	"errors"
 	"fmt"
-	"strings"
+	"regexp"
 )
 
 type fireboltSettings struct {
@@ -13,73 +14,43 @@ type fireboltSettings struct {
 	accountName string
 }
 
-// splitString split string into two string, when first split char is encountered
-// return two strings:
-//    - first string before the encountered character, with removed backtick escape
-//    - second string is remaining string, including the character on which it was split
-func splitString(str string, splitChars []uint8) (string, string) {
-	var res string
-	for i := 0; i < len(str); i++ {
-		if str[i] == '\\' {
-			res += string(str[i+1])
-			i += 1
-			continue
-		}
-		for _, v := range splitChars {
-			if str[i] == v {
-				return res, str[i:]
-			}
-		}
-		res += string(str[i])
-	}
-	return res, ""
-}
-
-// parseRemainingDSN checks whether dsn has an expected prefix, removes it, and return two strings:
-//    - before the stopChars
-//    - after the stopChars, including the char itself
-func parseRemainingDSN(dsn string, expectedPrefix string, stopChars []uint8) (string, string, error) {
-	if !strings.HasPrefix(dsn, expectedPrefix) {
-		return "", dsn, fmt.Errorf("expected prefix not found: %s", expectedPrefix)
-	}
-
-	dsn = dsn[len(expectedPrefix):]
-	res, dsn := splitString(dsn, stopChars)
-	return res, dsn, nil
-}
+const dsnPattern = `^firebolt://(?P<username>.*@.*):(?P<password>.*)@(?P<database>\w+)(?:/(?P<engine>[^?]+))?(?:\?(?P<parameters>\w+\=[^=&]+(?:\&\w+=[^=&]+)*))?$`
+const paramsPattern = `(?P<key>\w+)=(?P<value>[^=&]+)`
 
 // ParseDSNString parses a dsn in a format: firebolt://username:password@db_name[/engine_name][?account_name=organization]
 // returns a settings object where all parsed values are populated
 // returns an error if required fields couldn't be parsed or if after parsing some characters were left unparsed
 func ParseDSNString(dsn string) (*fireboltSettings, error) {
 	var result fireboltSettings
+	dsnExpr := regexp.MustCompile(dsnPattern)
+	paramsExpr := regexp.MustCompile(paramsPattern)
 
-	var err error
+	infolog.Println("Parsing DSN")
+	dsnMatch := dsnExpr.FindStringSubmatch(dsn)
 
-	// parse username
-	result.username, dsn, err = parseRemainingDSN(dsn, "firebolt://", []uint8{':'})
-	if err != nil {
-		return nil, ConstructNestedError("error during username parsing", err)
+	if len(dsnMatch) == 0 {
+		return nil, errors.New("invalid connection string format")
 	}
 
-	// parse password
-	result.password, dsn, err = parseRemainingDSN(dsn, ":", []uint8{'@'})
-	if err != nil {
-		return nil, ConstructNestedError("error during password parsing", err)
+	result.username = dsnMatch[1]
+	result.password = dsnMatch[2]
+	result.database = dsnMatch[3]
+	if len(dsnMatch[4]) > 0 {
+		// engine name was provided
+		result.engineName = dsnMatch[4]
 	}
 
-	// parse database
-	result.database, dsn, err = parseRemainingDSN(dsn, "@", []uint8{'/', '?'})
-	if err != nil {
-		return nil, ConstructNestedError("error during database parsing", err)
-	}
-
-	// parse engine and account names
-	result.engineName, dsn, _ = parseRemainingDSN(dsn, "/", []uint8{'?'})
-	result.accountName, dsn, _ = parseRemainingDSN(dsn, "?account_name=", []uint8{})
-
-	if len(dsn) != 0 {
-		return nil, fmt.Errorf("unparsed characters were found: %s", dsn)
+	paramsStr := dsnMatch[2]
+	if len(paramsStr) > 0 {
+		paramsMatch := paramsExpr.FindAllStringSubmatch(paramsStr, -1)
+		for _, m := range paramsMatch {
+			switch m[1] {
+			case "account_name":
+				result.accountName = m[2]
+			default:
+				return nil, fmt.Errorf("unknown parameter name %s", m[1])
+			}
+		}
 	}
 
 	return &result, nil

--- a/dsn.go
+++ b/dsn.go
@@ -14,7 +14,7 @@ type fireboltSettings struct {
 	accountName string
 }
 
-const dsnPattern = `^firebolt://(?P<username>.*@.*):(?P<password>.*)@(?P<database>\w+)(?:/(?P<engine>[^?]+))?(?:\?(?P<parameters>\w+\=[^=&]+(?:\&\w+=[^=&]+)*))?$`
+const dsnPattern = `^firebolt://(?P<username>.*@?.*):(?P<password>.*)@(?P<database>\w+)(?:/(?P<engine>[^?]+))?(?:\?(?P<parameters>\w+\=[^=&]+(?:\&\w+=[^=&]+)*))?$`
 const paramsPattern = `(?P<key>\w+)=(?P<value>[^=&]+)`
 
 // ParseDSNString parses a dsn in a format: firebolt://username:password@db_name[/engine_name][?account_name=organization]

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -56,6 +56,9 @@ func TestDSNHappyPath(t *testing.T) {
 
 	runDSNTest(t, "firebolt://user@fire:bolt.io:passwo@rd@db_name?account_name=firebolt_account",
 		fireboltSettings{username: "user@fire:bolt.io", password: "passwo@rd", database: "db_name", accountName: "firebolt_account"})
+
+	runDSNTest(t, "firebolt://client_id:client_secret@db_name?account_name=firebolt_account",
+		fireboltSettings{username: "client_id", password: "client_secret", database: "db_name", accountName: "firebolt_account"})
 }
 
 // TestDSNFailed test different failure scenarios for ParseDSNString
@@ -65,5 +68,4 @@ func TestDSNFailed(t *testing.T) {
 	runDSNTestFail(t, "firebolt://user:yury_db")
 	runDSNTestFail(t, "jdbc://user:yury_db@db_name")
 	runDSNTestFail(t, "firebolt://yury_db@dn_name?account_name=firebolt_account")
-	runDSNTestFail(t, "firebolt://yury_db:password@dn_name?account=fi")
 }

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -8,7 +8,7 @@ func runDSNTest(t *testing.T, input string, expectedSettings fireboltSettings) {
 	settings, err := ParseDSNString(input)
 
 	if err != nil {
-		t.Errorf("Unexpected failed")
+		t.Errorf("Unexpected failure for %s: %s", input, err)
 	}
 
 	if settings.username != expectedSettings.username {
@@ -48,13 +48,13 @@ func TestDSNHappyPath(t *testing.T) {
 	runDSNTest(t, "firebolt://user@firebolt.io:password@db_name/engine_url.firebolt.io",
 		fireboltSettings{username: "user@firebolt.io", password: "password", database: "db_name", engineName: "engine_url.firebolt.io"})
 
-	runDSNTest(t, "firebolt://user@firebolt.io:password@db_name/https:\\/\\/engine_url.firebolt.io",
+	runDSNTest(t, "firebolt://user@firebolt.io:password@db_name/https://engine_url.firebolt.io",
 		fireboltSettings{username: "user@firebolt.io", password: "password", database: "db_name", engineName: "https://engine_url.firebolt.io"})
 
 	runDSNTest(t, "firebolt://user@firebolt.io:password@db_name?account_name=firebolt_account",
 		fireboltSettings{username: "user@firebolt.io", password: "password", database: "db_name", accountName: "firebolt_account"})
 
-	runDSNTest(t, "firebolt://user@fire\\:bolt.io:passwo\\@rd@db_name?account_name=firebolt_account",
+	runDSNTest(t, "firebolt://user@fire:bolt.io:passwo@rd@db_name?account_name=firebolt_account",
 		fireboltSettings{username: "user@fire:bolt.io", password: "passwo@rd", database: "db_name", accountName: "firebolt_account"})
 }
 
@@ -66,24 +66,4 @@ func TestDSNFailed(t *testing.T) {
 	runDSNTestFail(t, "jdbc://user:yury_db@db_name")
 	runDSNTestFail(t, "firebolt://yury_db@dn_name?account_name=firebolt_account")
 	runDSNTestFail(t, "firebolt://yury_db:password@dn_name?account=fi")
-}
-
-func runTestSplitString(t *testing.T, str string, stopChars []uint8, expectedFirst, expectedSecond string) {
-	first, second := splitString(str, stopChars)
-	if first != expectedFirst {
-		t.Errorf("splitString result is not as expected: %s != %s", first, expectedFirst)
-	}
-	if second != expectedSecond {
-		t.Errorf("splitString result is not as expected: %s != %s", second, expectedSecond)
-	}
-}
-
-//TestSplitString tests several possible scenarios for SplitString function
-func TestSplitString(t *testing.T) {
-	runTestSplitString(t, "some_str", []uint8{}, "some_str", "")
-	runTestSplitString(t, "some_str", []uint8{'r'}, "some_st", "r")
-	runTestSplitString(t, "some_str", []uint8{'s', 'o', 'm'}, "", "some_str")
-	runTestSplitString(t, "", []uint8{'s', 'o', 'm'}, "", "")
-	runTestSplitString(t, "", []uint8{}, "", "")
-	runTestSplitString(t, "some_str", []uint8{'_'}, "some", "_str")
 }


### PR DESCRIPTION
Updated DSN parser to use regexp under the hood to add support for special symbols in password