### PR TITLE
feat: add support for nan and inf

### DIFF
--- a/driver_integration_test.go
+++ b/driver_integration_test.go
@@ -61,9 +61,9 @@ func TestDriverQueryResult(t *testing.T) {
 		t.Errorf("failed unexpectedly with %v", err)
 	}
 	rows, err := db.Query(
-		"SELECT CAST('2020-01-03 19:08:45' AS DATETIME) as dt, CAST('2020-01-03' AS DATE) as d, CAST(1 AS INT) as i, CAST(-1/0 as FLOAT) " +
+		"SELECT CAST('2020-01-03 19:08:45' AS DATETIME) as dt, CAST('2020-01-03' AS DATE) as d, CAST(1 AS INT) as i, CAST(-1/0 as FLOAT) as f" +
 			"UNION " +
-			"SELECT CAST('2021-01-03 19:38:34' AS DATETIME) as dt, CAST('2000-12-03' AS DATE) as d, CAST(2 AS INT) as i, CAST(0/0 as FLOAT) ORDER BY i")
+			"SELECT CAST('2021-01-03 19:38:34' AS DATETIME) as dt, CAST('2000-12-03' AS DATE) as d, CAST(2 AS INT) as i, CAST(0/0 as FLOAT) as f ORDER BY i")
 	if err != nil {
 		t.Errorf("db.Query returned an error: %v", err)
 	}

--- a/driver_integration_test.go
+++ b/driver_integration_test.go
@@ -7,8 +7,10 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"math"
 	"os"
 	"reflect"
+	"runtime/debug"
 	"strings"
 	"testing"
 	"time"
@@ -59,16 +61,17 @@ func TestDriverQueryResult(t *testing.T) {
 		t.Errorf("failed unexpectedly with %v", err)
 	}
 	rows, err := db.Query(
-		"SELECT CAST('2020-01-03 19:08:45' AS DATETIME) as dt, CAST('2020-01-03' AS DATE) as d, CAST(1 AS INT) as i " +
+		"SELECT CAST('2020-01-03 19:08:45' AS DATETIME) as dt, CAST('2020-01-03' AS DATE) as d, CAST(1 AS INT) as i, CAST(-1/0 as FLOAT) " +
 			"UNION " +
-			"SELECT CAST('2021-01-03 19:38:34' AS DATETIME) as dt, CAST('2000-12-03' AS DATE) as d, CAST(2 AS INT) as i ORDER BY i")
+			"SELECT CAST('2021-01-03 19:38:34' AS DATETIME) as dt, CAST('2000-12-03' AS DATE) as d, CAST(2 AS INT) as i, CAST(0/0 as FLOAT) ORDER BY i")
 	if err != nil {
 		t.Errorf("db.Query returned an error: %v", err)
 	}
 	var dt, d time.Time
 	var i int
+	var f float64
 
-	expectedColumns := []string{"dt", "d", "i"}
+	expectedColumns := []string{"dt", "d", "i", "f"}
 	if columns, err := rows.Columns(); reflect.DeepEqual(expectedColumns, columns) && err != nil {
 		t.Errorf("columns are not equal (%v != %v) and error is %v", expectedColumns, columns, err)
 	}
@@ -76,18 +79,23 @@ func TestDriverQueryResult(t *testing.T) {
 	if !rows.Next() {
 		t.Errorf("Next returned end of output")
 	}
-	assert(rows.Scan(&dt, &d, &i), nil, t, "Scan returned an error")
+	assert(rows.Scan(&dt, &d, &i, &f), nil, t, "Scan returned an error")
 	assert(dt, time.Date(2020, 01, 03, 19, 8, 45, 0, loc), t, "results not equal for datetime")
 	assert(d, time.Date(2020, 01, 03, 0, 0, 0, 0, loc), t, "results not equal for date")
 	assert(i, 1, t, "results not equal for int")
+	assert(f, math.Inf(-1), t, "results not equal for float")
 
 	if !rows.Next() {
 		t.Errorf("Next returned end of output")
 	}
-	assert(rows.Scan(&dt, &d, &i), nil, t, "Scan returned an error")
+	assert(rows.Scan(&dt, &d, &i, &f), nil, t, "Scan returned an error")
 	assert(dt, time.Date(2021, 01, 03, 19, 38, 34, 0, loc), t, "results not equal for datetime")
 	assert(d, time.Date(2000, 12, 03, 0, 0, 0, 0, loc), t, "results not equal for date")
 	assert(i, 2, t, "results not equal for int")
+	if !math.IsNaN(f) {
+		t.Log(string(debug.Stack()))
+		t.Errorf("results not equal for float Expected: NaN Got: %f", f)
+	}
 
 	if rows.Next() {
 		t.Errorf("Next didn't returned false, although no data is expected")

--- a/driver_integration_test.go
+++ b/driver_integration_test.go
@@ -61,7 +61,7 @@ func TestDriverQueryResult(t *testing.T) {
 		t.Errorf("failed unexpectedly with %v", err)
 	}
 	rows, err := db.Query(
-		"SELECT CAST('2020-01-03 19:08:45' AS DATETIME) as dt, CAST('2020-01-03' AS DATE) as d, CAST(1 AS INT) as i, CAST(-1/0 as FLOAT) as f" +
+		"SELECT CAST('2020-01-03 19:08:45' AS DATETIME) as dt, CAST('2020-01-03' AS DATE) as d, CAST(1 AS INT) as i, CAST(-1/0 as FLOAT) as f " +
 			"UNION " +
 			"SELECT CAST('2021-01-03 19:38:34' AS DATETIME) as dt, CAST('2000-12-03' AS DATE) as d, CAST(2 AS INT) as i, CAST(0/0 as FLOAT) as f ORDER BY i")
 	if err != nil {

--- a/rows.go
+++ b/rows.go
@@ -151,8 +151,7 @@ func parseDateTimeValue(columnType string, value string) (driver.Value, error) {
 }
 
 func parseFloatValue(val interface{}) (float64, error) {
-	fmt.Printf("parseFloatValue: %v\n", val)
-	if _, ok := val.(string); ok {
+	if _, notNum := val.(string); notNum {
 		switch val.(string) {
 		case "inf":
 			return math.Inf(1), nil


### PR DESCRIPTION
Added support for `nan` and `inf` (both positive and negative) values, coming from backend. They are converted to `math.NaN` and `math.Inf` values