### PR TITLE
fix: fix time and float formatting issues

### DIFF
--- a/connection_integration_test.go
+++ b/connection_integration_test.go
@@ -288,7 +288,8 @@ func TestConnectionPreparedStatement(t *testing.T) {
 	loc, _ := time.LoadLocation("Europe/Berlin")
 
 	d := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
-	ts := time.Date(2021, 1, 1, 2, 10, 20, 3000, loc)
+	ts := time.Date(2021, 1, 1, 2, 10, 20, 3000, time.UTC)
+	tstz := time.Date(2021, 1, 1, 2, 10, 20, 3000, loc)
 	ba := []byte("abc123")
 
 	_, err = conn.QueryContext(
@@ -302,7 +303,7 @@ func TestConnectionPreparedStatement(t *testing.T) {
 			{Name: "t", Value: "text"},
 			{Name: "d", Value: d},
 			{Name: "ts", Value: ts},
-			{Name: "tstz", Value: ts},
+			{Name: "tstz", Value: tstz},
 			{Name: "b", Value: true},
 			{Name: "ba", Value: ba},
 		},
@@ -343,8 +344,8 @@ func TestConnectionPreparedStatement(t *testing.T) {
 	assert(dest[5], d, t, "date results are not equal")
 	assert(dest[6], ts.UTC(), t, "timestamp results are not equal")
 	// Use .Equal to correctly compare timezones
-	if !dest[7].(time.Time).Equal(ts) {
-		t.Errorf("timestamptz results are not equal Expected: %s Got: %s", ts, dest[7])
+	if !dest[7].(time.Time).Equal(tstz) {
+		t.Errorf("timestamptz results are not equal Expected: %s Got: %s", tstz, dest[7])
 	}
 	assert(dest[8], true, t, "boolean results are not equal")
 	baValue := dest[9].([]byte)

--- a/connection_integration_test.go
+++ b/connection_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"database/sql/driver"
 	"io"
 	"reflect"
+	"runtime/debug"
 	"testing"
 	"time"
 )
@@ -258,5 +259,104 @@ func TestConnectionQueryByteaType(t *testing.T) {
 	expected := []byte("abc123")
 	if !bytes.Equal(to_test, expected) {
 		t.Errorf("Bytea type check failed Expected: %s Got: %s", expected, to_test)
+	}
+}
+
+func TestConnectionPreparedStatement(t *testing.T) {
+	conn := fireboltConnection{clientMock, databaseMock, engineUrlMock, map[string]string{}}
+
+	_, err := conn.QueryContext(
+		context.Background(),
+		"DROP TABLE IF EXISTS test_prepared_statements",
+		nil,
+	)
+	if err != nil {
+		t.Errorf("drop table statement failed with %v", err)
+		t.FailNow()
+	}
+
+	_, err = conn.QueryContext(
+		context.Background(),
+		"CREATE TABLE test_prepared_statements (i INT, l LONG, f FLOAT, d DOUBLE, t TEXT, dt DATE, ts TIMESTAMP, tstz TIMESTAMPTZ, b BOOLEAN, ba BYTEA) PRIMARY INDEX i",
+		nil,
+	)
+	if err != nil {
+		t.Errorf("create table statement failed with %v", err)
+		t.FailNow()
+	}
+
+	loc, _ := time.LoadLocation("Europe/Berlin")
+
+	d := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	ts := time.Date(2021, 1, 1, 2, 10, 20, 3000, loc)
+	ba := []byte("abc123")
+
+	_, err = conn.QueryContext(
+		context.Background(),
+		"INSERT INTO test_prepared_statements VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+		[]driver.NamedValue{
+			{Name: "i", Value: 1},
+			{Name: "l", Value: int64(2)},
+			{Name: "f", Value: 0.333333},
+			{Name: "dt", Value: 0.333333333333},
+			{Name: "t", Value: "text"},
+			{Name: "d", Value: d},
+			{Name: "ts", Value: ts},
+			{Name: "tstz", Value: ts},
+			{Name: "b", Value: true},
+			{Name: "ba", Value: ba},
+		},
+	)
+
+	if err != nil {
+		t.Errorf("insert statement failed with %v", err)
+		t.FailNow()
+	}
+
+	_, err = conn.QueryContext(context.Background(), "SET time_zone=Europe/Berlin", nil)
+	if err != nil {
+		t.Errorf("set time_zone statement failed with %v", err)
+		t.FailNow()
+	}
+
+	rows, err := conn.QueryContext(
+		context.Background(),
+		"SELECT * FROM test_prepared_statements",
+		nil,
+	)
+	if err != nil {
+		t.Errorf("select statement failed with %v", err)
+		t.FailNow()
+	}
+
+	dest := make([]driver.Value, 10)
+	if err = rows.Next(dest); err != nil {
+		t.Errorf("firebolt rows Next failed with %v", err)
+		t.FailNow()
+	}
+
+	assert(dest[0], int32(1), t, "int32 results are not equal")
+	assert(dest[1], int64(2), t, "int64 results are not equal")
+	assert(dest[2], float32(0.333333), t, "float32 results are not equal")
+	assert(dest[3], 0.333333333333, t, "float64 results are not equal")
+	assert(dest[4], "text", t, "string results are not equal")
+	assert(dest[5], d, t, "date results are not equal")
+	assert(dest[6], ts.UTC(), t, "timestamp results are not equal")
+	// Use .Equal to correctly compare timezones
+	if !dest[7].(time.Time).Equal(ts) {
+		t.Errorf("timestamptz results are not equal Expected: %s Got: %s", ts, dest[7])
+	}
+	assert(dest[8], true, t, "boolean results are not equal")
+	ba_value := dest[9].([]byte)
+	if len(ba_value) != len(ba) {
+		t.Log(string(debug.Stack()))
+		t.Errorf("bytea results are not equal Expected length: %d Got: %d", len(ba), len(ba_value))
+	}
+	for i := range ba {
+		if ba[i] != ba_value[i] {
+			t.Log(string(debug.Stack()))
+			t.Errorf("bytea results are not equal Expected: %s Got: %s", ba, ba_value)
+			break
+		}
 	}
 }

--- a/connection_integration_test.go
+++ b/connection_integration_test.go
@@ -347,15 +347,15 @@ func TestConnectionPreparedStatement(t *testing.T) {
 		t.Errorf("timestamptz results are not equal Expected: %s Got: %s", ts, dest[7])
 	}
 	assert(dest[8], true, t, "boolean results are not equal")
-	ba_value := dest[9].([]byte)
-	if len(ba_value) != len(ba) {
+	baValue := dest[9].([]byte)
+	if len(baValue) != len(ba) {
 		t.Log(string(debug.Stack()))
-		t.Errorf("bytea results are not equal Expected length: %d Got: %d", len(ba), len(ba_value))
+		t.Errorf("bytea results are not equal Expected length: %d Got: %d", len(ba), len(baValue))
 	}
 	for i := range ba {
-		if ba[i] != ba_value[i] {
+		if ba[i] != baValue[i] {
 			t.Log(string(debug.Stack()))
-			t.Errorf("bytea results are not equal Expected: %s Got: %s", ba, ba_value)
+			t.Errorf("bytea results are not equal Expected: %s Got: %s", ba, baValue)
 			break
 		}
 	}

--- a/utils.go
+++ b/utils.go
@@ -108,7 +108,7 @@ func formatValue(value driver.Value) (string, error) {
 	case int64, uint64, int32, uint32, int16, uint16, int8, uint8, int, uint:
 		return fmt.Sprintf("%d", value), nil
 	case float64, float32:
-		return fmt.Sprintf("%f", value), nil
+		return fmt.Sprintf("%g", value), nil
 	case bool:
 		if value.(bool) {
 			return "1", nil
@@ -116,7 +116,10 @@ func formatValue(value driver.Value) (string, error) {
 			return "0", nil
 		}
 	case time.Time:
-		return fmt.Sprintf("'%s'", value.(time.Time).Format("2006-01-02 15:04:05 -07:00")), nil
+		// Convert timestamp to UTC and don't add timezone to format
+		// This way we ensure that all Firebolt time types support this string,
+		// while providing the same time data to the engine
+		return fmt.Sprintf("'%s'", value.(time.Time).UTC().Format("2006-01-02 15:04:05")), nil
 	case nil:
 		return "NULL", nil
 	default:

--- a/utils.go
+++ b/utils.go
@@ -119,7 +119,21 @@ func formatValue(value driver.Value) (string, error) {
 		// Convert timestamp to UTC and don't add timezone to format
 		// This way we ensure that all Firebolt time types support this string,
 		// while providing the same time data to the engine
-		return fmt.Sprintf("'%s'", value.(time.Time).UTC().Format("2006-01-02 15:04:05")), nil
+		timeValue := value.(time.Time).UTC()
+		layout := "2006-01-02 15:04:05.000000"
+		// Subtract date part from value and check if remaining time part is zero
+		// If it is, use date only format
+		if timeValue.Sub(timeValue.Truncate(time.Hour*24)) == 0 {
+			layout = "2006-01-02"
+		}
+		return fmt.Sprintf("'%s'", timeValue.Format(layout)), nil
+	case []byte:
+		byteValue := value.([]byte)
+		parts := make([]string, len(byteValue))
+		for i, b := range byteValue {
+			parts[i] = fmt.Sprintf("\\x%02x", b)
+		}
+		return fmt.Sprintf("'%s'", strings.Join(parts, "")), nil
 	case nil:
 		return "NULL", nil
 	default:

--- a/utils.go
+++ b/utils.go
@@ -119,12 +119,15 @@ func formatValue(value driver.Value) (string, error) {
 		// Convert timestamp to UTC and don't add timezone to format
 		// This way we ensure that all Firebolt time types support this string,
 		// while providing the same time data to the engine
-		timeValue := value.(time.Time).UTC()
+		timeValue := value.(time.Time)
 		layout := "2006-01-02 15:04:05.000000"
 		// Subtract date part from value and check if remaining time part is zero
 		// If it is, use date only format
 		if timeValue.Sub(timeValue.Truncate(time.Hour*24)) == 0 {
 			layout = "2006-01-02"
+		} else if _, offset := timeValue.Zone(); offset != 0 {
+			// If we have a timezone info, add it to format
+			layout = "2006-01-02 15:04:05.000000-07:00"
 		}
 		return fmt.Sprintf("'%s'", timeValue.Format(layout)), nil
 	case []byte:

--- a/utils.go
+++ b/utils.go
@@ -116,9 +116,6 @@ func formatValue(value driver.Value) (string, error) {
 			return "0", nil
 		}
 	case time.Time:
-		// Convert timestamp to UTC and don't add timezone to format
-		// This way we ensure that all Firebolt time types support this string,
-		// while providing the same time data to the engine
 		timeValue := value.(time.Time)
 		layout := "2006-01-02 15:04:05.000000"
 		// Subtract date part from value and check if remaining time part is zero

--- a/utils_test.go
+++ b/utils_test.go
@@ -108,15 +108,17 @@ func TestFormatValue(t *testing.T) {
 	runTestFormatValue(t, "test' OR '1' == '1", "'test\\' OR \\'1\\' == \\'1'")
 
 	runTestFormatValue(t, 1, "1")
+	runTestFormatValue(t, 1.123, "1.123")
 	runTestFormatValue(t, 1.123456, "1.123456")
+	runTestFormatValue(t, 1.1234567, "1.1234567")
+	runTestFormatValue(t, 1/float64(3), "0.3333333333333333")
 	runTestFormatValue(t, true, "1")
 	runTestFormatValue(t, false, "0")
 	runTestFormatValue(t, -10, "-10")
 	runTestFormatValue(t, nil, "NULL")
-	runTestFormatValue(t, time.Date(2022, 01, 10, 1, 3, 2, 0, loc), "'2022-01-10 01:03:02 +01:00'")
+	// Timestamp is converted to UTC according to the provided loc value
+	runTestFormatValue(t, time.Date(2022, 01, 10, 2, 3, 2, 0, loc), "'2022-01-10 01:03:02'")
 
-	// not passing, but should: runTestFormatValue(t, 1.1234567, "1.1234567")
-	// not passing, but should: runTestFormatValue(t, 1.123, "1.123")
 }
 
 func TestConstructUserAgentString(t *testing.T) {

--- a/utils_test.go
+++ b/utils_test.go
@@ -116,6 +116,7 @@ func TestFormatValue(t *testing.T) {
 	runTestFormatValue(t, false, "0")
 	runTestFormatValue(t, -10, "-10")
 	runTestFormatValue(t, nil, "NULL")
+	runTestFormatValue(t, []byte("abcd"), "'\\x61\\x62\\x63\\x64'")
 	// Timestamp is converted to UTC according to the provided loc value
 	runTestFormatValue(t, time.Date(2022, 01, 10, 2, 3, 2, 123000, loc), "'2022-01-10 01:03:02.000123'")
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -117,7 +117,7 @@ func TestFormatValue(t *testing.T) {
 	runTestFormatValue(t, -10, "-10")
 	runTestFormatValue(t, nil, "NULL")
 	// Timestamp is converted to UTC according to the provided loc value
-	runTestFormatValue(t, time.Date(2022, 01, 10, 2, 3, 2, 0, loc), "'2022-01-10 01:03:02'")
+	runTestFormatValue(t, time.Date(2022, 01, 10, 2, 3, 2, 123000, loc), "'2022-01-10 01:03:02.000123'")
 
 }
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -117,8 +117,12 @@ func TestFormatValue(t *testing.T) {
 	runTestFormatValue(t, -10, "-10")
 	runTestFormatValue(t, nil, "NULL")
 	runTestFormatValue(t, []byte("abcd"), "'\\x61\\x62\\x63\\x64'")
-	// Timestamp is converted to UTC according to the provided loc value
-	runTestFormatValue(t, time.Date(2022, 01, 10, 2, 3, 2, 123000, loc), "'2022-01-10 01:03:02.000123'")
+	// Time
+	runTestFormatValue(t, time.Date(2022, 01, 10, 1, 3, 2, 123000, time.UTC), "'2022-01-10 01:03:02.000123'")
+	runTestFormatValue(t, time.Date(2022, 01, 10, 1, 3, 2, 123000, time.FixedZone("", 0)), "'2022-01-10 01:03:02.000123'")
+	runTestFormatValue(t, time.Date(2022, 01, 10, 0, 0, 0, 0, time.UTC), "'2022-01-10'")
+	runTestFormatValue(t, time.Date(2022, 01, 10, 0, 0, 0, 0, loc), "'2022-01-10 00:00:00.000000+01:00'")
+	runTestFormatValue(t, time.Date(2022, 01, 10, 1, 3, 2, 123000, loc), "'2022-01-10 01:03:02.000123+01:00'")
 
 }
 


### PR DESCRIPTION
Fixed value formatting issues
- Fixed time format, removed the timezone from string and added converting time to UTC before formatting. This results in the same data being stored in db, but this format is also supported by timezone unaware types.
- Removed the precision limit when formatting float values. It used to be 6 digits, not it's all the digits present in the value
- Added support for bytea formatting 