### PR TITLE
ci: update secret names

### DIFF
--- a/.github/workflows/integration-tests-v2.yml
+++ b/.github/workflows/integration-tests-v2.yml
@@ -26,9 +26,9 @@ on:
         required: false
       FIREBOLT_CLIENT_SECRET_STG_NEW_IDN:
         required: false
-      FIREBOLT_CLIENT_ID_NEW_IDN:
+      FIREBOLT_CLIENT_ID_DEV_NEW_IDN:
         required: false
-      FIREBOLT_CLIENT_SECRET_NEW_IDN:
+      FIREBOLT_CLIENT_SECRET_DEV_NEW_IDN:
         required: false
 
 jobs:
@@ -50,8 +50,8 @@ jobs:
              echo "CLIENT_ID=${{ secrets.FIREBOLT_CLIENT_ID_STG_NEW_IDN }}" >> "$GITHUB_ENV"
              echo "CLIENT_SECRET=${{ secrets.FIREBOLT_CLIENT_SECRET_STG_NEW_IDN }}" >> "$GITHUB_ENV"
           else
-             echo "CLIENT_ID=${{ secrets.FIREBOLT_CLIENT_ID_NEW_IDN }}" >> "$GITHUB_ENV"
-             echo "CLIENT_SECRET=${{ secrets.FIREBOLT_CLIENT_SECRET_NEW_IDN }}" >> "$GITHUB_ENV"
+             echo "CLIENT_ID=${{ secrets.FIREBOLT_CLIENT_ID_DEV_NEW_IDN }}" >> "$GITHUB_ENV"
+             echo "CLIENT_SECRET=${{ secrets.FIREBOLT_CLIENT_SECRET_DEV_NEW_IDN }}" >> "$GITHUB_ENV"
           fi
 
       - name: Keep environment name in the summary

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,9 +26,9 @@ on:
         required: false
       FIREBOLT_CLIENT_SECRET_STG_NEW_IDN:
         required: false
-      FIREBOLT_CLIENT_ID_NEW_IDN:
+      FIREBOLT_CLIENT_ID_DEV_NEW_IDN:
         required: false
-      FIREBOLT_CLIENT_SECRET_NEW_IDN:
+      FIREBOLT_CLIENT_SECRET_DEV_NEW_IDN:
         required: false
       FIREBOLT_USERNAME_STAGING:
         required: false

--- a/.github/workflows/nightly-v2.yml
+++ b/.github/workflows/nightly-v2.yml
@@ -35,8 +35,8 @@ jobs:
         id: setup
         uses: firebolt-db/integration-testing-setup@v2
         with:
-          firebolt-client-id: ${{ secrets.FIREBOLT_CLIENT_ID_NEW_IDN }}
-          firebolt-client-secret: ${{ secrets.FIREBOLT_CLIENT_SECRET_NEW_IDN }}
+          firebolt-client-id: ${{ secrets.FIREBOLT_CLIENT_ID_DEV_NEW_IDN }}
+          firebolt-client-secret: ${{ secrets.FIREBOLT_CLIENT_SECRET_DEV_NEW_IDN }}
           api-endpoint: "api.staging.firebolt.io"
           account: "developer"
           instance-type: "B2"
@@ -47,8 +47,8 @@ jobs:
           ENGINE_NAME: ${{ steps.setup.outputs.engine_name }}
           FIREBOLT_ENDPOINT: "api.staging.firebolt.io"
           ACCOUNT_NAME: "developer"
-          CLIENT_ID: ${{ secrets.FIREBOLT_CLIENT_ID_NEW_IDN }}
-          CLIENT_SECRET: ${{ secrets.FIREBOLT_CLIENT_SECRET_NEW_IDN }}
+          CLIENT_ID: ${{ secrets.FIREBOLT_CLIENT_ID_DEV_NEW_IDN }}
+          CLIENT_SECRET: ${{ secrets.FIREBOLT_CLIENT_SECRET_DEV_NEW_IDN }}
         run: |
           go test . -timeout=30m -v -coverprofile cover.out --tags=integration
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,13 @@ jobs:
       environment: 'staging'
       branch: main
     secrets:
+
       FIREBOLT_USERNAME_STAGING: ${{ secrets.FIREBOLT_USERNAME_STAGING }}
       FIREBOLT_PASSWORD_STAGING: ${{ secrets.FIREBOLT_PASSWORD_STAGING }}
       FIREBOLT_CLIENT_ID_STAGING: ${{ secrets.FIREBOLT_CLIENT_ID_STAGING }}
       FIREBOLT_CLIENT_SECRET_STAGING: ${{ secrets.FIREBOLT_CLIENT_SECRET_STAGING }}
+      FIREBOLT_CLIENT_ID_STG_NEW_IDN: ${{ secrets.FIREBOLT_CLIENT_ID_STG_NEW_IDN }}
+      FIREBOLT_CLIENT_SECRET_STG_NEW_IDN: ${{ secrets.FIREBOLT_CLIENT_SECRET_STG_NEW_IDN }}
 
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Updated secret names to use global secrets:
- `FIREBOLT_CLIENT_ID_NEW_IDN` -> `FIREBOLT_CLIENT_ID_DEV_NEW_IDN`
- `FIREBOLT_CLIENT_SECRET_NEW_IDN` -> `FIREBOLT_CLIENT_SECRET_DEV_NEW_IDN`
Also, added missing secrets when calling integration tests from a release action