### PR TITLE
feat: Fir 28441 support use database statement

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -67,13 +67,13 @@ func getAccessTokenUsernamePassword(username string, password string, apiEndpoin
 			return "", err
 		}
 		infolog.Printf("Start authentication into '%s' using '%s'", apiEndpoint, loginUrl)
-		resp, err, _, _ := request(context.TODO(), "", "POST", apiEndpoint+loginUrl, userAgent, nil, body, contentType)
-		if err != nil {
-			return "", ConstructNestedError("authentication request failed", err)
+		resp := request(context.TODO(), "", "POST", apiEndpoint+loginUrl, userAgent, nil, body, contentType)
+		if resp.err != nil {
+			return "", ConstructNestedError("authentication request failed", resp.err)
 		}
 
 		var authResp AuthenticationResponse
-		if err = jsonStrictUnmarshall(resp, &authResp); err != nil {
+		if err = jsonStrictUnmarshall(resp.data, &authResp); err != nil {
 			return "", ConstructNestedError("failed to unmarshal authentication response with error", err)
 		}
 		infolog.Printf("Authentication was successful")
@@ -116,13 +116,13 @@ func getAccessTokenServiceAccount(clientId string, clientSecret string, apiEndpo
 			return "", ConstructNestedError("error building auth endpoint", err)
 		}
 		infolog.Printf("Start authentication into '%s' using '%s'", authEndpoint, loginUrl)
-		resp, err, _, _ := request(context.TODO(), "", "POST", authEndpoint+loginUrl, userAgent, nil, body, contentType)
-		if err != nil {
-			return "", ConstructNestedError("authentication request failed", err)
+		resp := request(context.TODO(), "", "POST", authEndpoint+loginUrl, userAgent, nil, body, contentType)
+		if resp.err != nil {
+			return "", ConstructNestedError("authentication request failed", resp.err)
 		}
 
 		var authResp AuthenticationResponse
-		if err = jsonStrictUnmarshall(resp, &authResp); err != nil {
+		if err = jsonStrictUnmarshall(resp.data, &authResp); err != nil {
 			return "", ConstructNestedError("failed to unmarshal authentication response with error", err)
 		}
 		infolog.Printf("Authentication was successful")

--- a/auth.go
+++ b/auth.go
@@ -67,7 +67,7 @@ func getAccessTokenUsernamePassword(username string, password string, apiEndpoin
 			return "", err
 		}
 		infolog.Printf("Start authentication into '%s' using '%s'", apiEndpoint, loginUrl)
-		resp := request(context.TODO(), "", "POST", apiEndpoint+loginUrl, userAgent, nil, body, contentType)
+		resp := request(requestParameters{context.TODO(), "", "POST", apiEndpoint + loginUrl, userAgent, nil, body, contentType})
 		if resp.err != nil {
 			return "", ConstructNestedError("authentication request failed", resp.err)
 		}
@@ -116,7 +116,7 @@ func getAccessTokenServiceAccount(clientId string, clientSecret string, apiEndpo
 			return "", ConstructNestedError("error building auth endpoint", err)
 		}
 		infolog.Printf("Start authentication into '%s' using '%s'", authEndpoint, loginUrl)
-		resp := request(context.TODO(), "", "POST", authEndpoint+loginUrl, userAgent, nil, body, contentType)
+		resp := request(requestParameters{context.TODO(), "", "POST", authEndpoint + loginUrl, userAgent, nil, body, contentType})
 		if resp.err != nil {
 			return "", ConstructNestedError("authentication request failed", resp.err)
 		}

--- a/auth.go
+++ b/auth.go
@@ -67,7 +67,7 @@ func getAccessTokenUsernamePassword(username string, password string, apiEndpoin
 			return "", err
 		}
 		infolog.Printf("Start authentication into '%s' using '%s'", apiEndpoint, loginUrl)
-		resp, err, _ := request(context.TODO(), "", "POST", apiEndpoint+loginUrl, userAgent, nil, body, contentType)
+		resp, err, _, _ := request(context.TODO(), "", "POST", apiEndpoint+loginUrl, userAgent, nil, body, contentType)
 		if err != nil {
 			return "", ConstructNestedError("authentication request failed", err)
 		}
@@ -116,7 +116,7 @@ func getAccessTokenServiceAccount(clientId string, clientSecret string, apiEndpo
 			return "", ConstructNestedError("error building auth endpoint", err)
 		}
 		infolog.Printf("Start authentication into '%s' using '%s'", authEndpoint, loginUrl)
-		resp, err, _ := request(context.TODO(), "", "POST", authEndpoint+loginUrl, userAgent, nil, body, contentType)
+		resp, err, _, _ := request(context.TODO(), "", "POST", authEndpoint+loginUrl, userAgent, nil, body, contentType)
 		if err != nil {
 			return "", ConstructNestedError("authentication request failed", err)
 		}

--- a/client.go
+++ b/client.go
@@ -49,7 +49,7 @@ func MakeClient(settings *fireboltSettings, apiEndpoint string) (*ClientImpl, er
 func (c *ClientImpl) getEngineUrlStatusDBByName(ctx context.Context, engineName string, systemEngineUrl string) (string, string, string, error) {
 	infolog.Printf("Get info for engine '%s'", engineName)
 	engineSQL := fmt.Sprintf(engineInfoSQL, engineName)
-	queryRes, err := c.Query(ctx, systemEngineUrl, "", engineSQL, make(map[string]string))
+	queryRes, err := c.Query(ctx, systemEngineUrl, engineSQL, make(map[string]string))
 	if err != nil {
 		return "", "", "", ConstructNestedError("error executing engine info sql query", err)
 	}
@@ -138,11 +138,8 @@ func (c *ClientImpl) getAccountID(ctx context.Context, accountName string) (stri
 	return accountIdURLResponse.Id, nil
 }
 
-func (c *ClientImpl) getQueryParams(databaseName string, setStatements map[string]string) (map[string]string, error) {
+func (c *ClientImpl) getQueryParams(setStatements map[string]string) (map[string]string, error) {
 	params := map[string]string{"output_format": outputFormat}
-	if len(databaseName) > 0 {
-		params["database"] = databaseName
-	}
 	for setKey, setValue := range setStatements {
 		params[setKey] = setValue
 	}

--- a/client.go
+++ b/client.go
@@ -49,7 +49,9 @@ func MakeClient(settings *fireboltSettings, apiEndpoint string) (*ClientImpl, er
 func (c *ClientImpl) getEngineUrlStatusDBByName(ctx context.Context, engineName string, systemEngineUrl string) (string, string, string, error) {
 	infolog.Printf("Get info for engine '%s'", engineName)
 	engineSQL := fmt.Sprintf(engineInfoSQL, engineName)
-	queryRes, err := c.Query(ctx, systemEngineUrl, engineSQL, make(map[string]string), func(key, value string) {})
+	queryRes, err := c.Query(ctx, systemEngineUrl, engineSQL, make(map[string]string), func(key, value string) {
+		// No need to support set statements for engine info query
+	})
 	if err != nil {
 		return "", "", "", ConstructNestedError("error executing engine info sql query", err)
 	}

--- a/client.go
+++ b/client.go
@@ -49,7 +49,7 @@ func MakeClient(settings *fireboltSettings, apiEndpoint string) (*ClientImpl, er
 func (c *ClientImpl) getEngineUrlStatusDBByName(ctx context.Context, engineName string, systemEngineUrl string) (string, string, string, error) {
 	infolog.Printf("Get info for engine '%s'", engineName)
 	engineSQL := fmt.Sprintf(engineInfoSQL, engineName)
-	queryRes, err := c.Query(ctx, systemEngineUrl, engineSQL, make(map[string]string))
+	queryRes, err := c.Query(ctx, systemEngineUrl, engineSQL, make(map[string]string), func(key, value string) {})
 	if err != nil {
 		return "", "", "", ConstructNestedError("error executing engine info sql query", err)
 	}

--- a/client.go
+++ b/client.go
@@ -94,17 +94,17 @@ func (c *ClientImpl) getSystemEngineURL(ctx context.Context, accountName string)
 
 	url := fmt.Sprintf(c.ApiEndpoint+EngineUrlByAccountName, accountName)
 
-	response, _, err_code, err := c.request(ctx, "GET", url, make(map[string]string), "")
-	if err_code == 404 {
+	resp := c.request(ctx, "GET", url, make(map[string]string), "")
+	if resp.statusCode == 404 {
 		return "", fmt.Errorf(accountError, accountName)
 	}
-	if err != nil {
-		return "", ConstructNestedError("error during system engine url http request", err)
+	if resp.err != nil {
+		return "", ConstructNestedError("error during system engine url http request", resp.err)
 	}
 
 	var systemEngineURLResponse SystemEngineURLResponse
-	if err = json.Unmarshal(response, &systemEngineURLResponse); err != nil {
-		return "", ConstructNestedError("error during unmarshalling system engine URL response", errors.New(string(response)))
+	if err := json.Unmarshal(resp.data, &systemEngineURLResponse); err != nil {
+		return "", ConstructNestedError("error during unmarshalling system engine URL response", errors.New(string(resp.data)))
 	}
 
 	return systemEngineURLResponse.EngineUrl, nil
@@ -120,17 +120,17 @@ func (c *ClientImpl) getAccountID(ctx context.Context, accountName string) (stri
 
 	url := fmt.Sprintf(c.ApiEndpoint+AccountIdByAccountName, accountName)
 
-	response, _, err_code, err := c.request(ctx, "GET", url, make(map[string]string), "")
-	if err_code == 404 {
+	resp := c.request(ctx, "GET", url, make(map[string]string), "")
+	if resp.statusCode == 404 {
 		return "", fmt.Errorf(accountError, accountName)
 	}
-	if err != nil {
-		return "", ConstructNestedError("error during account id resolution http request", err)
+	if resp.err != nil {
+		return "", ConstructNestedError("error during account id resolution http request", resp.err)
 	}
 
 	var accountIdURLResponse AccountIdURLResponse
-	if err = json.Unmarshal(response, &accountIdURLResponse); err != nil {
-		return "", ConstructNestedError("error during unmarshalling account id resolution URL response", errors.New(string(response)))
+	if err := json.Unmarshal(resp.data, &accountIdURLResponse); err != nil {
+		return "", ConstructNestedError("error during unmarshalling account id resolution URL response", errors.New(string(resp.data)))
 	}
 
 	infolog.Printf("Resolved account %s to id %s", accountName, accountIdURLResponse.Id)

--- a/client.go
+++ b/client.go
@@ -94,7 +94,7 @@ func (c *ClientImpl) getSystemEngineURL(ctx context.Context, accountName string)
 
 	url := fmt.Sprintf(c.ApiEndpoint+EngineUrlByAccountName, accountName)
 
-	response, err, err_code := c.request(ctx, "GET", url, make(map[string]string), "")
+	response, _, err_code, err := c.request(ctx, "GET", url, make(map[string]string), "")
 	if err_code == 404 {
 		return "", fmt.Errorf(accountError, accountName)
 	}
@@ -120,7 +120,7 @@ func (c *ClientImpl) getAccountID(ctx context.Context, accountName string) (stri
 
 	url := fmt.Sprintf(c.ApiEndpoint+AccountIdByAccountName, accountName)
 
-	response, err, err_code := c.request(ctx, "GET", url, make(map[string]string), "")
+	response, _, err_code, err := c.request(ctx, "GET", url, make(map[string]string), "")
 	if err_code == 404 {
 		return "", fmt.Errorf(accountError, accountName)
 	}

--- a/client_base.go
+++ b/client_base.go
@@ -56,7 +56,7 @@ func (c *BaseClient) Query(ctx context.Context, engineUrl, query string, paramet
 
 	resp := c.request(ctx, "POST", engineUrl, params, query)
 	if resp.err != nil {
-		return nil, ConstructNestedError("error during query request", err)
+		return nil, ConstructNestedError("error during query request", resp.err)
 	}
 
 	if err = processResponseHeaders(resp.headers, updateParameters); err != nil {

--- a/client_base.go
+++ b/client_base.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"slices"
 	"strings"
 )
 
@@ -77,6 +76,16 @@ func (c *BaseClient) Query(ctx context.Context, engineUrl, query string, paramet
 	return &queryResponse, nil
 }
 
+// check whether a string is present in a slice
+func contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}
+
 func processResponseHeaders(headers http.Header, updateParameters func(string, string)) error {
 	if updateParametersRaw, ok := headers[updateParametersHeader]; ok {
 		updateParametersPairs := strings.Split(updateParametersRaw[0], ",")
@@ -85,7 +94,7 @@ func processResponseHeaders(headers http.Header, updateParameters func(string, s
 			if len(kv) != 2 {
 				return fmt.Errorf("invalid parameter assignment %s", parameter)
 			}
-			if slices.Contains(allowedUpdateParameters, kv[0]) {
+			if contains(allowedUpdateParameters, kv[0]) {
 				updateParameters(kv[0], kv[1])
 			} else {
 				infolog.Printf("Warning: received unknown update parameter %s", kv[0])

--- a/client_base.go
+++ b/client_base.go
@@ -17,7 +17,7 @@ const protocolVersion = "2.0"
 
 type Client interface {
 	GetEngineUrlAndDB(ctx context.Context, engineName string, accountId string) (string, string, error)
-	Query(ctx context.Context, engineUrl, databaseName, query string, setStatements map[string]string) (*QueryResponse, error)
+	Query(ctx context.Context, engineUrl, query string, parameters map[string]string) (*QueryResponse, error)
 }
 
 type BaseClient struct {
@@ -26,18 +26,18 @@ type BaseClient struct {
 	AccountID         string
 	ApiEndpoint       string
 	UserAgent         string
-	parameterGetter   func(string, map[string]string) (map[string]string, error)
+	parameterGetter   func(map[string]string) (map[string]string, error)
 	accessTokenGetter func() (string, error)
 }
 
 // Query sends a query to the engine URL and populates queryResponse, if query was successful
-func (c *BaseClient) Query(ctx context.Context, engineUrl, databaseName, query string, setStatements map[string]string) (*QueryResponse, error) {
+func (c *BaseClient) Query(ctx context.Context, engineUrl, query string, parameters map[string]string) (*QueryResponse, error) {
 	infolog.Printf("Query engine '%s' with '%s'", engineUrl, query)
 
 	if c.parameterGetter == nil {
 		return nil, errors.New("parameterGetter is not set")
 	}
-	params, err := c.parameterGetter(databaseName, setStatements)
+	params, err := c.parameterGetter(parameters)
 	if err != nil {
 		return nil, err
 	}

--- a/client_base.go
+++ b/client_base.go
@@ -12,6 +12,8 @@ import (
 )
 
 const outputFormat = "JSON_Compact"
+const protocolVersionHeader = "Firebolt-Protocol-Version"
+const protocolVersion = "2.0"
 
 type Client interface {
 	GetEngineUrlAndDB(ctx context.Context, engineName string, accountId string) (string, string, error)
@@ -127,6 +129,9 @@ func request(ctx context.Context, accessToken string, method string, url string,
 
 	// adding sdk usage tracking
 	req.Header.Set("User-Agent", userAgent)
+
+	// add protocol version header
+	req.Header.Set(protocolVersionHeader, protocolVersion)
 
 	if len(accessToken) > 0 {
 		var bearer = "Bearer " + accessToken

--- a/client_base.go
+++ b/client_base.go
@@ -213,7 +213,7 @@ func request(
 		}
 		return response{nil, resp.StatusCode, nil, fmt.Errorf("request returned non ok status code: %d, %s", resp.StatusCode, string(body))}
 	}
-	co
+
 	return response{body, resp.StatusCode, resp.Header, nil}
 }
 

--- a/client_common_test.go
+++ b/client_common_test.go
@@ -19,7 +19,9 @@ func testProtocolVersion(t *testing.T, clientFactory func(string) Client) {
 
 	client := clientFactory(server.URL)
 
-	_, _ = client.Query(context.TODO(), server.URL, "SELECT 1", map[string]string{}, func(key, value string) {})
+	_, _ = client.Query(context.TODO(), server.URL, "SELECT 1", map[string]string{}, func(key, value string) {
+		// Do nothing
+	})
 	if protocolVersionValue != protocolVersion {
 		t.Errorf("Did not set Protocol-Version value correctly on a query request")
 	}

--- a/client_common_test.go
+++ b/client_common_test.go
@@ -1,0 +1,56 @@
+package fireboltgosdk
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func testProtocolVersion(t *testing.T, clientFactory func(string) Client) {
+	var protocolVersionValue = ""
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		protocolVersionValue = r.Header.Get(protocolVersionHeader)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	prepareEnvVariablesForTest(t, server)
+
+	client := clientFactory(server.URL)
+
+	_, _ = client.Query(context.TODO(), server.URL, "SELECT 1", map[string]string{}, func(key, value string) {})
+	if protocolVersionValue != protocolVersion {
+		t.Errorf("Did not set Protocol-Version value correctly on a query request")
+	}
+}
+
+func testUpdateParameters(t *testing.T, clientFactory func(string) Client) {
+	var newDatabaseName = "new_database"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == ServiceAccountLoginURLSuffix {
+			_, _ = w.Write(getAuthResponse(10000))
+		} else if r.URL.Path == UsernamePasswordURLSuffix {
+			_, _ = w.Write(getAuthResponseV0(10000))
+		} else {
+			w.Header().Set(updateParametersHeader, fmt.Sprintf("%s=%s", "database", newDatabaseName))
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+	prepareEnvVariablesForTest(t, server)
+	client := clientFactory(server.URL)
+
+	params := map[string]string{
+		"database": "db",
+	}
+	_, err := client.Query(context.TODO(), server.URL, "SELECT 1", params, func(key, value string) {
+		params[key] = value
+	})
+	if err != nil {
+		t.Errorf("Error during query execution with update parameters header in response %s", err)
+	}
+	if params["database"] != newDatabaseName {
+		t.Errorf("Database is not set correctly. Expected %s but was %s", newDatabaseName, params["database"])
+	}
+}

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -36,7 +36,7 @@ func TestGetEnginePropsByName(t *testing.T) {
 
 // TestQuery tests simple query
 func TestQuery(t *testing.T) {
-	queryResponse, err := clientMock.Query(context.TODO(), engineUrlMock, "SELECT 1", map[string]string{"database": databaseMock})
+	queryResponse, err := clientMock.Query(context.TODO(), engineUrlMock, "SELECT 1", map[string]string{"database": databaseMock}, func(key, value string) {})
 	if err != nil {
 		t.Errorf("Query returned an error: %v", err)
 	}
@@ -52,10 +52,10 @@ func TestQuery(t *testing.T) {
 // TestQuery with set statements
 func TestQuerySetStatements(t *testing.T) {
 	query := "SELECT * FROM information_schema.tables"
-	if _, err := clientMock.Query(context.TODO(), engineUrlMock, query, map[string]string{"use_standard_sql": "1", "database": databaseMock}); err != nil {
+	if _, err := clientMock.Query(context.TODO(), engineUrlMock, query, map[string]string{"use_standard_sql": "1", "database": databaseMock}, func(key, value string) {}); err != nil {
 		t.Errorf("Query returned an error: %v", err)
 	}
-	if _, err := clientMock.Query(context.TODO(), engineUrlMock, query, map[string]string{"use_standard_sql": "0", "database": databaseMock}); err == nil {
+	if _, err := clientMock.Query(context.TODO(), engineUrlMock, query, map[string]string{"use_standard_sql": "0", "database": databaseMock}, func(key, value string) {}); err == nil {
 		t.Errorf("Query didn't return an error, but should")
 	}
 }

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -36,7 +36,7 @@ func TestGetEnginePropsByName(t *testing.T) {
 
 // TestQuery tests simple query
 func TestQuery(t *testing.T) {
-	queryResponse, err := clientMock.Query(context.TODO(), engineUrlMock, databaseMock, "SELECT 1", nil)
+	queryResponse, err := clientMock.Query(context.TODO(), engineUrlMock, "SELECT 1", map[string]string{"database": databaseMock})
 	if err != nil {
 		t.Errorf("Query returned an error: %v", err)
 	}
@@ -52,10 +52,10 @@ func TestQuery(t *testing.T) {
 // TestQuery with set statements
 func TestQuerySetStatements(t *testing.T) {
 	query := "SELECT * FROM information_schema.tables"
-	if _, err := clientMock.Query(context.TODO(), engineUrlMock, databaseMock, query, map[string]string{"use_standard_sql": "1"}); err != nil {
+	if _, err := clientMock.Query(context.TODO(), engineUrlMock, query, map[string]string{"use_standard_sql": "1", "database": databaseMock}); err != nil {
 		t.Errorf("Query returned an error: %v", err)
 	}
-	if _, err := clientMock.Query(context.TODO(), engineUrlMock, databaseMock, query, map[string]string{"use_standard_sql": "0"}); err == nil {
+	if _, err := clientMock.Query(context.TODO(), engineUrlMock, query, map[string]string{"use_standard_sql": "0", "database": databaseMock}); err == nil {
 		t.Errorf("Query didn't return an error, but should")
 	}
 }

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -36,7 +36,9 @@ func TestGetEnginePropsByName(t *testing.T) {
 
 // TestQuery tests simple query
 func TestQuery(t *testing.T) {
-	queryResponse, err := clientMock.Query(context.TODO(), engineUrlMock, "SELECT 1", map[string]string{"database": databaseMock}, func(key, value string) {})
+	queryResponse, err := clientMock.Query(context.TODO(), engineUrlMock, "SELECT 1", map[string]string{"database": databaseMock}, func(key, value string) {
+		// Do nothing
+	})
 	if err != nil {
 		t.Errorf("Query returned an error: %v", err)
 	}
@@ -52,10 +54,14 @@ func TestQuery(t *testing.T) {
 // TestQuery with set statements
 func TestQuerySetStatements(t *testing.T) {
 	query := "SELECT * FROM information_schema.tables"
-	if _, err := clientMock.Query(context.TODO(), engineUrlMock, query, map[string]string{"use_standard_sql": "1", "database": databaseMock}, func(key, value string) {}); err != nil {
+	if _, err := clientMock.Query(context.TODO(), engineUrlMock, query, map[string]string{"use_standard_sql": "1", "database": databaseMock}, func(key, value string) {
+		// Do nothing
+	}); err != nil {
 		t.Errorf("Query returned an error: %v", err)
 	}
-	if _, err := clientMock.Query(context.TODO(), engineUrlMock, query, map[string]string{"use_standard_sql": "0", "database": databaseMock}, func(key, value string) {}); err == nil {
+	if _, err := clientMock.Query(context.TODO(), engineUrlMock, query, map[string]string{"use_standard_sql": "0", "database": databaseMock}, func(key, value string) {
+		// Do nothing
+	}); err == nil {
 		t.Errorf("Query didn't return an error, but should")
 	}
 }

--- a/client_integration_v0_test.go
+++ b/client_integration_v0_test.go
@@ -87,7 +87,9 @@ func TestGetEngineUrlByDatabase(t *testing.T) {
 
 // TestQuery tests simple query
 func TestQuery(t *testing.T) {
-	queryResponse, err := clientMock.Query(context.TODO(), engineUrlMock, "SELECT 1", map[string]string{"database": databaseMock}, func(string, string) {})
+	queryResponse, err := clientMock.Query(context.TODO(), engineUrlMock, "SELECT 1", map[string]string{"database": databaseMock}, func(string, string) {
+		// Do nothing
+	})
 	if err != nil {
 		t.Errorf("Query returned an error: %v", err)
 	}
@@ -103,10 +105,14 @@ func TestQuery(t *testing.T) {
 // TestQuery with set statements
 func TestQuerySetStatements(t *testing.T) {
 	query := "SELECT * FROM information_schema.tables"
-	if _, err := clientMock.Query(context.TODO(), engineUrlMock, query, map[string]string{"use_standard_sql": "1", "database": databaseMock}, func(string, string) {}); err != nil {
+	if _, err := clientMock.Query(context.TODO(), engineUrlMock, query, map[string]string{"use_standard_sql": "1", "database": databaseMock}, func(string, string) {
+		// Do nothing
+	}); err != nil {
 		t.Errorf("Query returned an error: %v", err)
 	}
-	if _, err := clientMock.Query(context.TODO(), engineUrlMock, query, map[string]string{"use_standard_sql": "0", "database": databaseMock}, func(string, string) {}); err == nil {
+	if _, err := clientMock.Query(context.TODO(), engineUrlMock, query, map[string]string{"use_standard_sql": "0", "database": databaseMock}, func(string, string) {
+		// Do nothing
+	}); err == nil {
 		t.Errorf("Query didn't return an error, but should")
 	}
 }

--- a/client_integration_v0_test.go
+++ b/client_integration_v0_test.go
@@ -87,7 +87,7 @@ func TestGetEngineUrlByDatabase(t *testing.T) {
 
 // TestQuery tests simple query
 func TestQuery(t *testing.T) {
-	queryResponse, err := clientMock.Query(context.TODO(), engineUrlMock, databaseMock, "SELECT 1", nil)
+	queryResponse, err := clientMock.Query(context.TODO(), engineUrlMock, "SELECT 1", map[string]string{"database": databaseMock})
 	if err != nil {
 		t.Errorf("Query returned an error: %v", err)
 	}
@@ -103,10 +103,10 @@ func TestQuery(t *testing.T) {
 // TestQuery with set statements
 func TestQuerySetStatements(t *testing.T) {
 	query := "SELECT * FROM information_schema.tables"
-	if _, err := clientMock.Query(context.TODO(), engineUrlMock, databaseMock, query, map[string]string{"use_standard_sql": "1"}); err != nil {
+	if _, err := clientMock.Query(context.TODO(), engineUrlMock, query, map[string]string{"use_standard_sql": "1", "database": databaseMock}); err != nil {
 		t.Errorf("Query returned an error: %v", err)
 	}
-	if _, err := clientMock.Query(context.TODO(), engineUrlMock, databaseMock, query, map[string]string{"use_standard_sql": "0"}); err == nil {
+	if _, err := clientMock.Query(context.TODO(), engineUrlMock, query, map[string]string{"use_standard_sql": "0", "database": databaseMock}); err == nil {
 		t.Errorf("Query didn't return an error, but should")
 	}
 }

--- a/client_integration_v0_test.go
+++ b/client_integration_v0_test.go
@@ -87,7 +87,7 @@ func TestGetEngineUrlByDatabase(t *testing.T) {
 
 // TestQuery tests simple query
 func TestQuery(t *testing.T) {
-	queryResponse, err := clientMock.Query(context.TODO(), engineUrlMock, "SELECT 1", map[string]string{"database": databaseMock})
+	queryResponse, err := clientMock.Query(context.TODO(), engineUrlMock, "SELECT 1", map[string]string{"database": databaseMock}, func(string, string) {})
 	if err != nil {
 		t.Errorf("Query returned an error: %v", err)
 	}
@@ -103,10 +103,10 @@ func TestQuery(t *testing.T) {
 // TestQuery with set statements
 func TestQuerySetStatements(t *testing.T) {
 	query := "SELECT * FROM information_schema.tables"
-	if _, err := clientMock.Query(context.TODO(), engineUrlMock, query, map[string]string{"use_standard_sql": "1", "database": databaseMock}); err != nil {
+	if _, err := clientMock.Query(context.TODO(), engineUrlMock, query, map[string]string{"use_standard_sql": "1", "database": databaseMock}, func(string, string) {}); err != nil {
 		t.Errorf("Query returned an error: %v", err)
 	}
-	if _, err := clientMock.Query(context.TODO(), engineUrlMock, query, map[string]string{"use_standard_sql": "0", "database": databaseMock}); err == nil {
+	if _, err := clientMock.Query(context.TODO(), engineUrlMock, query, map[string]string{"use_standard_sql": "0", "database": databaseMock}, func(string, string) {}); err == nil {
 		t.Errorf("Query didn't return an error, but should")
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -161,7 +161,7 @@ func TestUserAgent(t *testing.T) {
 	client.accessTokenGetter = client.getAccessToken
 	client.parameterGetter = client.getQueryParams
 
-	_, _ = client.Query(context.TODO(), server.URL, "dummy", "SELECT 1", map[string]string{})
+	_, _ = client.Query(context.TODO(), server.URL, "SELECT 1", map[string]string{})
 	if userAgentHeader != userAgentValue {
 		t.Errorf("Did not set User-Agent value correctly on a query request")
 	}
@@ -182,7 +182,7 @@ func TestProtocolVersion(t *testing.T) {
 	client.accessTokenGetter = client.getAccessToken
 	client.parameterGetter = client.getQueryParams
 
-	_, _ = client.Query(context.TODO(), server.URL, "dummy", "SELECT 1", map[string]string{})
+	_, _ = client.Query(context.TODO(), server.URL, "SELECT 1", map[string]string{})
 	if protocolVersionValue != protocolVersion {
 		t.Errorf("Did not set Protocol-Version value correctly on a query request")
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -161,7 +161,7 @@ func TestUserAgent(t *testing.T) {
 	client.accessTokenGetter = client.getAccessToken
 	client.parameterGetter = client.getQueryParams
 
-	_, _ = client.Query(context.TODO(), server.URL, "SELECT 1", map[string]string{})
+	_, _ = client.Query(context.TODO(), server.URL, "SELECT 1", map[string]string{}, func(key, value string) {})
 	if userAgentHeader != userAgentValue {
 		t.Errorf("Did not set User-Agent value correctly on a query request")
 	}
@@ -182,7 +182,7 @@ func TestProtocolVersion(t *testing.T) {
 	client.accessTokenGetter = client.getAccessToken
 	client.parameterGetter = client.getQueryParams
 
-	_, _ = client.Query(context.TODO(), server.URL, "SELECT 1", map[string]string{})
+	_, _ = client.Query(context.TODO(), server.URL, "SELECT 1", map[string]string{}, func(key, value string) {})
 	if protocolVersionValue != protocolVersion {
 		t.Errorf("Did not set Protocol-Version value correctly on a query request")
 	}
@@ -210,7 +210,9 @@ func TestUpdateParameters(t *testing.T) {
 	params := map[string]string{
 		"database": "db",
 	}
-	_, err := client.Query(context.TODO(), server.URL, "SELECT 1", params)
+	_, err := client.Query(context.TODO(), server.URL, "SELECT 1", params, func(key, value string) {
+		params[key] = value
+	})
 	if err != nil {
 		t.Errorf("Error during query execution with update parameters header in response %s", err)
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -217,7 +217,7 @@ func TestUpdateParameters(t *testing.T) {
 		t.Errorf("Error during query execution with update parameters header in response %s", err)
 	}
 	if params["database"] != newDatabaseName {
-		t.Errorf("Did not set Update-Parameters value correctly")
+		t.Errorf("Database is not set correctly. Expected %s but was %s", newDatabaseName, params["database"])
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -167,6 +167,27 @@ func TestUserAgent(t *testing.T) {
 	}
 }
 
+// TestProtocolVersion tests that protocol version is correctly set on request
+func TestProtocolVersion(t *testing.T) {
+	var protocolVersionValue = ""
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		protocolVersionValue = r.Header.Get(protocolVersionHeader)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	prepareEnvVariablesForTest(t, server)
+	var client = &ClientImpl{
+		BaseClient: BaseClient{ClientID: "client_id", ClientSecret: "client_secret", ApiEndpoint: server.URL},
+	}
+	client.accessTokenGetter = client.getAccessToken
+	client.parameterGetter = client.getQueryParams
+
+	_, _ = client.Query(context.TODO(), server.URL, "dummy", "SELECT 1", map[string]string{})
+	if protocolVersionValue != protocolVersion {
+		t.Errorf("Did not set Protocol-Version value correctly on a query request")
+	}
+}
+
 func getAuthResponse(expiry int) []byte {
 	var response = `{
    "access_token": "aMysteriousToken",

--- a/client_test.go
+++ b/client_test.go
@@ -39,7 +39,7 @@ func TestCacheAccessToken(t *testing.T) {
 	client.accessTokenGetter = client.getAccessToken
 	var err error
 	for i := 0; i < 3; i++ {
-		_, err, _ = client.request(context.TODO(), "GET", server.URL, nil, "")
+		_, _, _, err = client.request(context.TODO(), "GET", server.URL, nil, "")
 		if err != nil {
 			t.Errorf("Did not expect an error %s", err)
 		}
@@ -83,7 +83,7 @@ func TestRefreshTokenOn401(t *testing.T) {
 		BaseClient: BaseClient{ClientID: "client_id", ClientSecret: "client_secret", ApiEndpoint: server.URL, UserAgent: "userAgent"},
 	}
 	client.accessTokenGetter = client.getAccessToken
-	_, _, _ = client.request(context.TODO(), "GET", server.URL, nil, "")
+	_, _, _, _ = client.request(context.TODO(), "GET", server.URL, nil, "")
 
 	if getCachedAccessToken("client_id", server.URL) != "aMysteriousToken" {
 		t.Errorf("Did not fetch missing token")
@@ -120,10 +120,10 @@ func TestFetchTokenWhenExpired(t *testing.T) {
 		BaseClient: BaseClient{ClientID: "client_id", ClientSecret: "client_secret", ApiEndpoint: server.URL, UserAgent: "userAgent"},
 	}
 	client.accessTokenGetter = client.getAccessToken
-	_, _, _ = client.request(context.TODO(), "GET", server.URL, nil, "")
+	_, _, _, _ = client.request(context.TODO(), "GET", server.URL, nil, "")
 	// Waiting for the token to get expired
 	time.Sleep(2 * time.Millisecond)
-	_, _, _ = client.request(context.TODO(), "GET", server.URL, nil, "")
+	_, _, _, _ = client.request(context.TODO(), "GET", server.URL, nil, "")
 
 	token, _ := getAccessTokenUsernamePassword("client_id", "", server.URL, "")
 

--- a/client_test.go
+++ b/client_test.go
@@ -37,11 +37,10 @@ func TestCacheAccessToken(t *testing.T) {
 		BaseClient: BaseClient{ClientID: "client_id", ClientSecret: "client_secret", ApiEndpoint: server.URL, UserAgent: "userAgent"},
 	}
 	client.accessTokenGetter = client.getAccessToken
-	var err error
 	for i := 0; i < 3; i++ {
-		_, _, _, err = client.request(context.TODO(), "GET", server.URL, nil, "")
-		if err != nil {
-			t.Errorf("Did not expect an error %s", err)
+		resp := client.request(context.TODO(), "GET", server.URL, nil, "")
+		if resp.err != nil {
+			t.Errorf("Did not expect an error %s", resp.err)
 		}
 	}
 
@@ -83,7 +82,7 @@ func TestRefreshTokenOn401(t *testing.T) {
 		BaseClient: BaseClient{ClientID: "client_id", ClientSecret: "client_secret", ApiEndpoint: server.URL, UserAgent: "userAgent"},
 	}
 	client.accessTokenGetter = client.getAccessToken
-	_, _, _, _ = client.request(context.TODO(), "GET", server.URL, nil, "")
+	_ = client.request(context.TODO(), "GET", server.URL, nil, "")
 
 	if getCachedAccessToken("client_id", server.URL) != "aMysteriousToken" {
 		t.Errorf("Did not fetch missing token")
@@ -120,10 +119,10 @@ func TestFetchTokenWhenExpired(t *testing.T) {
 		BaseClient: BaseClient{ClientID: "client_id", ClientSecret: "client_secret", ApiEndpoint: server.URL, UserAgent: "userAgent"},
 	}
 	client.accessTokenGetter = client.getAccessToken
-	_, _, _, _ = client.request(context.TODO(), "GET", server.URL, nil, "")
+	_ = client.request(context.TODO(), "GET", server.URL, nil, "")
 	// Waiting for the token to get expired
 	time.Sleep(2 * time.Millisecond)
-	_, _, _, _ = client.request(context.TODO(), "GET", server.URL, nil, "")
+	_ = client.request(context.TODO(), "GET", server.URL, nil, "")
 
 	token, _ := getAccessTokenUsernamePassword("client_id", "", server.URL, "")
 

--- a/client_test.go
+++ b/client_test.go
@@ -160,7 +160,9 @@ func TestUserAgent(t *testing.T) {
 	client.accessTokenGetter = client.getAccessToken
 	client.parameterGetter = client.getQueryParams
 
-	_, _ = client.Query(context.TODO(), server.URL, "SELECT 1", map[string]string{}, func(key, value string) {})
+	_, _ = client.Query(context.TODO(), server.URL, "SELECT 1", map[string]string{}, func(key, value string) {
+		// Do nothing
+	})
 	if userAgentHeader != userAgentValue {
 		t.Errorf("Did not set User-Agent value correctly on a query request")
 	}

--- a/client_v0.go
+++ b/client_v0.go
@@ -42,7 +42,7 @@ func (c *ClientImplV0) getAccountIDByName(ctx context.Context, accountName strin
 
 	params := map[string]string{"account_name": accountName}
 
-	response, err, _ := c.request(ctx, "GET", c.ApiEndpoint+AccountIdByNameURL, params, "")
+	response, _, _, err := c.request(ctx, "GET", c.ApiEndpoint+AccountIdByNameURL, params, "")
 	if err != nil {
 		return "", ConstructNestedError("error during getting account id by name request", err)
 	}
@@ -64,7 +64,7 @@ func (c *ClientImplV0) getDefaultAccountID(ctx context.Context) (string, error) 
 		Account AccountResponse `json:"account"`
 	}
 
-	response, err, _ := c.request(ctx, "GET", fmt.Sprintf(c.ApiEndpoint+DefaultAccountURL), make(map[string]string), "")
+	response, _, _, err := c.request(ctx, "GET", fmt.Sprintf(c.ApiEndpoint+DefaultAccountURL), make(map[string]string), "")
 	if err != nil {
 		return "", ConstructNestedError("error during getting default account id request", err)
 	}
@@ -105,7 +105,7 @@ func (c *ClientImplV0) getEngineIdByName(ctx context.Context, engineName string,
 	}
 
 	params := map[string]string{"engine_name": engineName}
-	response, err, _ := c.request(ctx, "GET", fmt.Sprintf(c.ApiEndpoint+EngineIdByNameURL, accountId), params, "")
+	response, _, _, err := c.request(ctx, "GET", fmt.Sprintf(c.ApiEndpoint+EngineIdByNameURL, accountId), params, "")
 	if err != nil {
 		return "", ConstructNestedError("error during getting engine id by name request", err)
 	}
@@ -128,7 +128,7 @@ func (c *ClientImplV0) getEngineUrlById(ctx context.Context, engineId string, ac
 		Engine EngineResponse `json:"engine"`
 	}
 
-	response, err, _ := c.request(ctx, "GET", fmt.Sprintf(c.ApiEndpoint+EngineByIdURL, accountId, engineId), make(map[string]string), "")
+	response, _, _, err := c.request(ctx, "GET", fmt.Sprintf(c.ApiEndpoint+EngineByIdURL, accountId, engineId), make(map[string]string), "")
 
 	if err != nil {
 		return "", ConstructNestedError("error during getting engine url by id request", err)
@@ -167,7 +167,7 @@ func (c *ClientImplV0) getEngineUrlByDatabase(ctx context.Context, databaseName 
 	}
 
 	params := map[string]string{"database_name": databaseName}
-	response, err, _ := c.request(ctx, "GET", fmt.Sprintf(c.ApiEndpoint+EngineUrlByDatabaseNameURL, accountId), params, "")
+	response, _, _, err := c.request(ctx, "GET", fmt.Sprintf(c.ApiEndpoint+EngineUrlByDatabaseNameURL, accountId), params, "")
 	if err != nil {
 		return "", ConstructNestedError("error during getting engine url by database request", err)
 	}

--- a/client_v0.go
+++ b/client_v0.go
@@ -202,8 +202,8 @@ func (c *ClientImplV0) GetEngineUrlAndDB(ctx context.Context, engineName, databa
 
 }
 
-func (c *ClientImplV0) getQueryParams(databaseName string, setStatements map[string]string) (map[string]string, error) {
-	params := map[string]string{"database": databaseName, "output_format": outputFormat}
+func (c *ClientImplV0) getQueryParams(setStatements map[string]string) (map[string]string, error) {
+	params := map[string]string{"output_format": outputFormat}
 	for setKey, setValue := range setStatements {
 		params[setKey] = setValue
 	}

--- a/client_v0.go
+++ b/client_v0.go
@@ -42,14 +42,14 @@ func (c *ClientImplV0) getAccountIDByName(ctx context.Context, accountName strin
 
 	params := map[string]string{"account_name": accountName}
 
-	response, _, _, err := c.request(ctx, "GET", c.ApiEndpoint+AccountIdByNameURL, params, "")
-	if err != nil {
-		return "", ConstructNestedError("error during getting account id by name request", err)
+	resp := c.request(ctx, "GET", c.ApiEndpoint+AccountIdByNameURL, params, "")
+	if resp.err != nil {
+		return "", ConstructNestedError("error during getting account id by name request", resp.err)
 	}
 
 	var accountIdByNameResponse AccountIdByNameResponse
-	if err = json.Unmarshal(response, &accountIdByNameResponse); err != nil {
-		return "", ConstructNestedError("error during unmarshalling account id by name response", errors.New(string(response)))
+	if err := json.Unmarshal(resp.data, &accountIdByNameResponse); err != nil {
+		return "", ConstructNestedError("error during unmarshalling account id by name response", errors.New(string(resp.data)))
 	}
 	return accountIdByNameResponse.AccountId, nil
 }
@@ -64,14 +64,14 @@ func (c *ClientImplV0) getDefaultAccountID(ctx context.Context) (string, error) 
 		Account AccountResponse `json:"account"`
 	}
 
-	response, _, _, err := c.request(ctx, "GET", fmt.Sprintf(c.ApiEndpoint+DefaultAccountURL), make(map[string]string), "")
-	if err != nil {
-		return "", ConstructNestedError("error during getting default account id request", err)
+	resp := c.request(ctx, "GET", fmt.Sprintf(c.ApiEndpoint+DefaultAccountURL), make(map[string]string), "")
+	if resp.err != nil {
+		return "", ConstructNestedError("error during getting default account id request", resp.err)
 	}
 
 	var defaultAccountResponse DefaultAccountResponse
-	if err = json.Unmarshal(response, &defaultAccountResponse); err != nil {
-		return "", ConstructNestedError("error during unmarshalling default account response", errors.New(string(response)))
+	if err := json.Unmarshal(resp.data, &defaultAccountResponse); err != nil {
+		return "", ConstructNestedError("error during unmarshalling default account response", errors.New(string(resp.data)))
 	}
 
 	return defaultAccountResponse.Account.Id, nil
@@ -105,14 +105,14 @@ func (c *ClientImplV0) getEngineIdByName(ctx context.Context, engineName string,
 	}
 
 	params := map[string]string{"engine_name": engineName}
-	response, _, _, err := c.request(ctx, "GET", fmt.Sprintf(c.ApiEndpoint+EngineIdByNameURL, accountId), params, "")
-	if err != nil {
-		return "", ConstructNestedError("error during getting engine id by name request", err)
+	resp := c.request(ctx, "GET", fmt.Sprintf(c.ApiEndpoint+EngineIdByNameURL, accountId), params, "")
+	if resp.err != nil {
+		return "", ConstructNestedError("error during getting engine id by name request", resp.err)
 	}
 
 	var engineIdByNameResponse EngineIdByNameResponse
-	if err = json.Unmarshal(response, &engineIdByNameResponse); err != nil {
-		return "", ConstructNestedError("error during unmarshalling engine id by name response", errors.New(string(response)))
+	if err := json.Unmarshal(resp.data, &engineIdByNameResponse); err != nil {
+		return "", ConstructNestedError("error during unmarshalling engine id by name response", errors.New(string(resp.data)))
 	}
 	return engineIdByNameResponse.EngineId.EngineId, nil
 }
@@ -128,15 +128,15 @@ func (c *ClientImplV0) getEngineUrlById(ctx context.Context, engineId string, ac
 		Engine EngineResponse `json:"engine"`
 	}
 
-	response, _, _, err := c.request(ctx, "GET", fmt.Sprintf(c.ApiEndpoint+EngineByIdURL, accountId, engineId), make(map[string]string), "")
+	resp := c.request(ctx, "GET", fmt.Sprintf(c.ApiEndpoint+EngineByIdURL, accountId, engineId), make(map[string]string), "")
 
-	if err != nil {
-		return "", ConstructNestedError("error during getting engine url by id request", err)
+	if resp.err != nil {
+		return "", ConstructNestedError("error during getting engine url by id request", resp.err)
 	}
 
 	var engineByIdResponse EngineByIdResponse
-	if err = json.Unmarshal(response, &engineByIdResponse); err != nil {
-		return "", ConstructNestedError("error during unmarshalling engine url by id response", errors.New(string(response)))
+	if err := json.Unmarshal(resp.data, &engineByIdResponse); err != nil {
+		return "", ConstructNestedError("error during unmarshalling engine url by id response", errors.New(string(resp.data)))
 	}
 	return makeCanonicalUrl(engineByIdResponse.Engine.Endpoint), nil
 }
@@ -167,14 +167,14 @@ func (c *ClientImplV0) getEngineUrlByDatabase(ctx context.Context, databaseName 
 	}
 
 	params := map[string]string{"database_name": databaseName}
-	response, _, _, err := c.request(ctx, "GET", fmt.Sprintf(c.ApiEndpoint+EngineUrlByDatabaseNameURL, accountId), params, "")
-	if err != nil {
-		return "", ConstructNestedError("error during getting engine url by database request", err)
+	resp := c.request(ctx, "GET", fmt.Sprintf(c.ApiEndpoint+EngineUrlByDatabaseNameURL, accountId), params, "")
+	if resp.err != nil {
+		return "", ConstructNestedError("error during getting engine url by database request", resp.err)
 	}
 
 	var engineUrlByDatabaseResponse EngineUrlByDatabaseResponse
-	if err = json.Unmarshal(response, &engineUrlByDatabaseResponse); err != nil {
-		return "", ConstructNestedError("error during unmarshalling engine url by database response", errors.New(string(response)))
+	if err := json.Unmarshal(resp.data, &engineUrlByDatabaseResponse); err != nil {
+		return "", ConstructNestedError("error during unmarshalling engine url by database response", errors.New(string(resp.data)))
 	}
 	return engineUrlByDatabaseResponse.EngineUrl, nil
 }

--- a/client_v0_test.go
+++ b/client_v0_test.go
@@ -209,7 +209,7 @@ func TestUpdateParametersV0(t *testing.T) {
 		t.Errorf("Error during query execution with update parameters header in response %s", err)
 	}
 	if params["database"] != newDatabaseName {
-		t.Errorf("Did not set Update-Parameters value correctly")
+		t.Errorf("Database is not set correctly. Expected %s but was %s", newDatabaseName, params["database"])
 	}
 }
 

--- a/client_v0_test.go
+++ b/client_v0_test.go
@@ -30,11 +30,10 @@ func TestCacheAccessTokenV0(t *testing.T) {
 		BaseClient{ClientID: "ClientID@firebolt.io", ClientSecret: "password", ApiEndpoint: server.URL, UserAgent: "userAgent"},
 	}
 	client.accessTokenGetter = client.getAccessToken
-	var err error
 	for i := 0; i < 3; i++ {
-		_, _, _, err = client.request(context.TODO(), "GET", server.URL, nil, "")
-		if err != nil {
-			t.Errorf("Did not expect an error %s", err)
+		resp := client.request(context.TODO(), "GET", server.URL, nil, "")
+		if resp.err != nil {
+			t.Errorf("Did not expect an error %s", resp.err)
 		}
 	}
 
@@ -76,7 +75,7 @@ func TestRefreshTokenOn401V0(t *testing.T) {
 		BaseClient{ClientID: "ClientID@firebolt.io", ClientSecret: "password", ApiEndpoint: server.URL, UserAgent: "userAgent"},
 	}
 	client.accessTokenGetter = client.getAccessToken
-	_, _, _, _ = client.request(context.TODO(), "GET", server.URL, nil, "")
+	_ = client.request(context.TODO(), "GET", server.URL, nil, "")
 
 	if getCachedAccessToken("ClientID@firebolt.io", server.URL) != "aMysteriousToken" {
 		t.Errorf("Did not fetch missing token")
@@ -113,10 +112,10 @@ func TestFetchTokenWhenExpiredV0(t *testing.T) {
 		BaseClient{ClientID: "ClientID@firebolt.io", ClientSecret: "password", ApiEndpoint: server.URL, UserAgent: "userAgent"},
 	}
 	client.accessTokenGetter = client.getAccessToken
-	_, _, _, _ = client.request(context.TODO(), "GET", server.URL, nil, "")
+	_ = client.request(context.TODO(), "GET", server.URL, nil, "")
 	// Waiting for the token to get expired
 	time.Sleep(2 * time.Millisecond)
-	_, _, _, _ = client.request(context.TODO(), "GET", server.URL, nil, "")
+	_ = client.request(context.TODO(), "GET", server.URL, nil, "")
 
 	token, _ := getAccessTokenUsernamePassword("ClientID@firebolt.io", "", server.URL, "")
 

--- a/client_v0_test.go
+++ b/client_v0_test.go
@@ -152,7 +152,9 @@ func TestUserAgentV0(t *testing.T) {
 	client.accessTokenGetter = client.getAccessToken
 	client.parameterGetter = client.getQueryParams
 
-	_, _ = client.Query(context.TODO(), server.URL, "SELECT 1", map[string]string{}, func(key, value string) {})
+	_, _ = client.Query(context.TODO(), server.URL, "SELECT 1", map[string]string{}, func(key, value string) {
+		// Do nothing
+	})
 	if userAgentHeader != userAgentValue {
 		t.Errorf("Did not set User-Agent value correctly on a query request")
 	}

--- a/client_v0_test.go
+++ b/client_v0_test.go
@@ -159,6 +159,27 @@ func TestUserAgentV0(t *testing.T) {
 	}
 }
 
+// TestProtocolVersion tests that protocol version is correctly set on request
+func TestProtocolVersionV0(t *testing.T) {
+	var protocolVersionValue = ""
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		protocolVersionValue = r.Header.Get(protocolVersionHeader)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	prepareEnvVariablesForTest(t, server)
+	var client = &ClientImplV0{
+		BaseClient{ClientID: "ClientID@firebolt.io", ClientSecret: "password", ApiEndpoint: server.URL},
+	}
+	client.accessTokenGetter = client.getAccessToken
+	client.parameterGetter = client.getQueryParams
+
+	_, _ = client.Query(context.TODO(), server.URL, "dummy", "SELECT 1", map[string]string{})
+	if protocolVersionValue != protocolVersion {
+		t.Errorf("Did not set Protocol-Version value correctly on a query request")
+	}
+}
+
 func getAuthResponseV0(expiry int) []byte {
 	var response = `{
    "access_token": "aMysteriousToken",

--- a/client_v0_test.go
+++ b/client_v0_test.go
@@ -31,7 +31,7 @@ func TestCacheAccessTokenV0(t *testing.T) {
 	client.accessTokenGetter = client.getAccessToken
 	var err error
 	for i := 0; i < 3; i++ {
-		_, err, _ = client.request(context.TODO(), "GET", server.URL, nil, "")
+		_, _, _, err = client.request(context.TODO(), "GET", server.URL, nil, "")
 		if err != nil {
 			t.Errorf("Did not expect an error %s", err)
 		}
@@ -75,7 +75,7 @@ func TestRefreshTokenOn401V0(t *testing.T) {
 		BaseClient{ClientID: "ClientID@firebolt.io", ClientSecret: "password", ApiEndpoint: server.URL, UserAgent: "userAgent"},
 	}
 	client.accessTokenGetter = client.getAccessToken
-	_, _, _ = client.request(context.TODO(), "GET", server.URL, nil, "")
+	_, _, _, _ = client.request(context.TODO(), "GET", server.URL, nil, "")
 
 	if getCachedAccessToken("ClientID@firebolt.io", server.URL) != "aMysteriousToken" {
 		t.Errorf("Did not fetch missing token")
@@ -112,10 +112,10 @@ func TestFetchTokenWhenExpiredV0(t *testing.T) {
 		BaseClient{ClientID: "ClientID@firebolt.io", ClientSecret: "password", ApiEndpoint: server.URL, UserAgent: "userAgent"},
 	}
 	client.accessTokenGetter = client.getAccessToken
-	_, _, _ = client.request(context.TODO(), "GET", server.URL, nil, "")
+	_, _, _, _ = client.request(context.TODO(), "GET", server.URL, nil, "")
 	// Waiting for the token to get expired
 	time.Sleep(2 * time.Millisecond)
-	_, _, _ = client.request(context.TODO(), "GET", server.URL, nil, "")
+	_, _, _, _ = client.request(context.TODO(), "GET", server.URL, nil, "")
 
 	token, _ := getAccessTokenUsernamePassword("ClientID@firebolt.io", "", server.URL, "")
 

--- a/client_v0_test.go
+++ b/client_v0_test.go
@@ -154,7 +154,7 @@ func TestUserAgentV0(t *testing.T) {
 	client.accessTokenGetter = client.getAccessToken
 	client.parameterGetter = client.getQueryParams
 
-	_, _ = client.Query(context.TODO(), server.URL, "SELECT 1", map[string]string{})
+	_, _ = client.Query(context.TODO(), server.URL, "SELECT 1", map[string]string{}, func(key, value string) {})
 	if userAgentHeader != userAgentValue {
 		t.Errorf("Did not set User-Agent value correctly on a query request")
 	}
@@ -175,7 +175,7 @@ func TestProtocolVersionV0(t *testing.T) {
 	client.accessTokenGetter = client.getAccessToken
 	client.parameterGetter = client.getQueryParams
 
-	_, _ = client.Query(context.TODO(), server.URL, "SELECT 1", map[string]string{})
+	_, _ = client.Query(context.TODO(), server.URL, "SELECT 1", map[string]string{}, func(key, value string) {})
 	if protocolVersionValue != protocolVersion {
 		t.Errorf("Did not set Protocol-Version value correctly on a query request")
 	}
@@ -202,7 +202,9 @@ func TestUpdateParametersV0(t *testing.T) {
 	params := map[string]string{
 		"database": "db",
 	}
-	_, err := client.Query(context.TODO(), server.URL, "SELECT 1", params)
+	_, err := client.Query(context.TODO(), server.URL, "SELECT 1", params, func(key, value string) {
+		params[key] = value
+	})
 	if err != nil {
 		t.Errorf("Error during query execution with update parameters header in response %s", err)
 	}

--- a/client_v0_test.go
+++ b/client_v0_test.go
@@ -153,7 +153,7 @@ func TestUserAgentV0(t *testing.T) {
 	client.accessTokenGetter = client.getAccessToken
 	client.parameterGetter = client.getQueryParams
 
-	_, _ = client.Query(context.TODO(), server.URL, "dummy", "SELECT 1", map[string]string{})
+	_, _ = client.Query(context.TODO(), server.URL, "SELECT 1", map[string]string{})
 	if userAgentHeader != userAgentValue {
 		t.Errorf("Did not set User-Agent value correctly on a query request")
 	}
@@ -174,7 +174,7 @@ func TestProtocolVersionV0(t *testing.T) {
 	client.accessTokenGetter = client.getAccessToken
 	client.parameterGetter = client.getQueryParams
 
-	_, _ = client.Query(context.TODO(), server.URL, "dummy", "SELECT 1", map[string]string{})
+	_, _ = client.Query(context.TODO(), server.URL, "SELECT 1", map[string]string{})
 	if protocolVersionValue != protocolVersion {
 		t.Errorf("Did not set Protocol-Version value correctly on a query request")
 	}

--- a/connection.go
+++ b/connection.go
@@ -8,16 +8,15 @@ import (
 )
 
 type fireboltConnection struct {
-	client        Client
-	databaseName  string
-	engineUrl     string
-	setStatements map[string]string
+	client     Client
+	engineUrl  string
+	parameters map[string]string
 }
 
 // Prepare returns a firebolt prepared statement
 // returns an error if the connection isn't initialized or closed
 func (c *fireboltConnection) Prepare(query string) (driver.Stmt, error) {
-	if c.client != nil && len(c.databaseName) != 0 && len(c.engineUrl) != 0 {
+	if c.client != nil && len(c.engineUrl) != 0 {
 		return &fireboltStmt{execer: c, queryer: c, query: query}, nil
 	}
 	return nil, errors.New("fireboltConnection isn't properly initialized")
@@ -26,7 +25,7 @@ func (c *fireboltConnection) Prepare(query string) (driver.Stmt, error) {
 // Close closes the connection, and make the fireboltConnection unusable
 func (c *fireboltConnection) Close() error {
 	c.client = nil
-	c.databaseName = ""
+	c.parameters = make(map[string]string)
 	c.engineUrl = ""
 	return nil
 }
@@ -71,7 +70,7 @@ func (c *fireboltConnection) queryContextInternal(ctx context.Context, query str
 			}
 		}
 
-		if response, err := c.client.Query(ctx, c.engineUrl, c.databaseName, query, c.setStatements); err != nil {
+		if response, err := c.client.Query(ctx, c.engineUrl, query, c.parameters); err != nil {
 			return &rows, ConstructNestedError("error during query execution", err)
 		} else {
 			rows.response = append(rows.response, *response)
@@ -89,9 +88,17 @@ func processSetStatement(ctx context.Context, c *fireboltConnection, query strin
 		return false, nil
 	}
 
-	_, err = c.client.Query(ctx, c.engineUrl, c.databaseName, "SELECT 1", map[string]string{setKey: setValue})
+	if setKey == "database" {
+		return true, fmt.Errorf("`SET database` query is not allowed. Please use `USE database` syntax")
+	}
+
+	parameters := map[string]string{setKey: setValue}
+	if db, ok := c.parameters["database"]; ok {
+		parameters["database"] = db
+	}
+	_, err = c.client.Query(ctx, c.engineUrl, "SELECT 1", parameters)
 	if err == nil {
-		c.setStatements[setKey] = setValue
+		c.parameters[setKey] = setValue
 		return true, nil
 	}
 	return true, err

--- a/connection.go
+++ b/connection.go
@@ -89,10 +89,6 @@ func processSetStatement(ctx context.Context, c *fireboltConnection, query strin
 		return false, nil
 	}
 
-	if setKey == "database" {
-		return true, fmt.Errorf("`SET database` query is not allowed. Please use `USE database` syntax")
-	}
-
 	parameters := map[string]string{setKey: setValue}
 	if db, ok := c.parameters["database"]; ok {
 		parameters["database"] = db

--- a/connection.go
+++ b/connection.go
@@ -11,7 +11,7 @@ type fireboltConnection struct {
 	client     Client
 	engineUrl  string
 	parameters map[string]string
-	driver     *FireboltDriver
+	connector  *FireboltConnector
 }
 
 // Prepare returns a firebolt prepared statement
@@ -110,9 +110,9 @@ func (c *fireboltConnection) setParameter(key, value string) {
 		c.parameters = make(map[string]string)
 	}
 	c.parameters[key] = value
-	// Cache parameter in driver as well in case connection will be recreated by the pool
-	if c.driver.cachedParameters == nil {
-		c.driver.cachedParameters = make(map[string]string)
+	// Cache parameter in connector as well in case connection will be recreated by the pool
+	if c.connector.cachedParameters == nil {
+		c.connector.cachedParameters = make(map[string]string)
 	}
-	c.driver.cachedParameters[key] = value
+	c.connector.cachedParameters[key] = value
 }

--- a/connection_common_integration_test.go
+++ b/connection_common_integration_test.go
@@ -6,8 +6,8 @@ package fireboltgosdk
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"database/sql/driver"
-	"io"
 	"reflect"
 	"runtime/debug"
 	"testing"
@@ -16,287 +16,357 @@ import (
 
 // TestConnectionPrepareStatement, tests that prepare statement doesn't result into an error
 func TestConnectionSetStatement(t *testing.T) {
-	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}, nil}
+	conn, err := sql.Open("firebolt", dsnMock)
+	if err != nil {
+		t.Errorf("opening a connection failed unexpectedly")
+		t.FailNow()
+	}
 
-	_, err := conn.ExecContext(context.TODO(), "SET use_standard_sql=1", nil)
+	_, err = conn.ExecContext(context.TODO(), "SET use_standard_sql=1")
 	assert(err, nil, t, "set use_standard_sql returned an error, but shouldn't")
 
-	_, err = conn.QueryContext(context.TODO(), "SELECT * FROM information_schema.tables", nil)
+	_, err = conn.QueryContext(context.TODO(), "SELECT * FROM information_schema.tables")
 	assert(err, nil, t, "query returned an error, but shouldn't")
 
 }
 
 // TestConnectionQuery checks simple SELECT 1 exec
 func TestConnectionQueryWrong(t *testing.T) {
-	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}, nil}
+	conn, err := sql.Open("firebolt", dsnMock)
+	if err != nil {
+		t.Errorf("opening a connection failed unexpectedly")
+		t.FailNow()
+	}
 
-	if _, err := conn.ExecContext(context.TODO(), "SELECT wrong query", nil); err == nil {
+	if _, err = conn.ExecContext(context.TODO(), "SELECT wrong query"); err == nil {
 		t.Errorf("wrong statement didn't return an error")
 	}
 }
 
 // TestConnectionInsertQuery checks simple Insert works
 func TestConnectionInsertQuery(t *testing.T) {
-	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}, nil}
+	conn, err := sql.Open("firebolt", dsnMock)
+	if err != nil {
+		t.Errorf("opening a connection failed unexpectedly")
+		t.FailNow()
+	}
+
 	createTableSQL := "CREATE FACT TABLE integration_tests (id INT, name STRING) PRIMARY INDEX id"
 	deleteTableSQL := "DROP TABLE IF EXISTS integration_tests"
 	insertSQL := "INSERT INTO integration_tests (id, name) VALUES (0, 'some_text')"
 
-	if _, err := conn.ExecContext(context.TODO(), createTableSQL, nil); err != nil {
+	if _, err = conn.ExecContext(context.TODO(), createTableSQL); err != nil {
 		t.Errorf("statement returned an error: %v", err)
 	}
-	if _, err := conn.ExecContext(context.TODO(), "SET advanced_mode=1", nil); err != nil {
+	if _, err = conn.ExecContext(context.TODO(), insertSQL); err != nil {
 		t.Errorf("statement returned an error: %v", err)
 	}
-	if _, err := conn.ExecContext(context.TODO(), insertSQL, nil); err != nil {
-		t.Errorf("statement returned an error: %v", err)
-	}
-	if _, err := conn.ExecContext(context.TODO(), deleteTableSQL, nil); err != nil {
+	if _, err = conn.ExecContext(context.TODO(), deleteTableSQL); err != nil {
 		t.Errorf("statement returned an error: %v", err)
 	}
 }
 
 // TestConnectionQuery checks simple SELECT query
 func TestConnectionQuery(t *testing.T) {
-	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}, nil}
+	conn, err := sql.Open("firebolt", dsnMock)
+	if err != nil {
+		t.Errorf("opening a connection failed unexpectedly")
+		t.FailNow()
+	}
 
 	sql := "SELECT -3213212 as \"const\", 2.3 as \"float\", 'some_text' as \"text\""
-	rows, err := conn.QueryContext(context.TODO(), sql, nil)
+	rows, err := conn.QueryContext(context.TODO(), sql)
 	if err != nil {
 		t.Errorf("firebolt statement failed with %v", err)
 	}
 
 	columnNames := []string{"const", "float", "text"}
-	if !reflect.DeepEqual(rows.Columns(), columnNames) {
+	columns, err := rows.Columns()
+	if err != nil {
+		t.Errorf("columns returned an error, but shouldn't")
+	}
+	if !reflect.DeepEqual(columns, columnNames) {
 		t.Errorf("column lists are not equal")
 	}
 
-	dest := make([]driver.Value, 3)
-	err = rows.Next(dest)
+	var i int32
+	var f float64
+	var s string
+	assert(rows.Next(), true, t, "Next returned false")
+	err = rows.Scan(&i, &f, &s)
 	if err != nil {
 		t.Errorf("Next returned an error, but shouldn't")
 	}
-	assert(dest[0], int32(-3213212), t, "dest[0] is not equal")
-	assert(dest[1], float64(2.3), t, "dest[1] is not equal")
-	assert(dest[2], "some_text", t, "dest[2] is not equal")
+	assert(i, int32(-3213212), t, "dest[0] is not equal")
+	assert(f, float64(2.3), t, "dest[1] is not equal")
+	assert(s, "some_text", t, "dest[2] is not equal")
 
-	assert(rows.Next(dest), io.EOF, t, "end of data didn't return io.EOF")
+	assert(rows.Next(), false, t, "end of data didn't return io.EOF")
 }
 
 func TestConnectionQueryDate32Type(t *testing.T) {
-	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}, nil}
+	conn, err := sql.Open("firebolt", dsnMock)
+	if err != nil {
+		t.Errorf("opening a connection failed unexpectedly")
+		t.FailNow()
+	}
 	loc, _ := time.LoadLocation("UTC")
 
-	rows, err := conn.QueryContext(context.TODO(), "select '2004-07-09'::DATE", nil)
+	rows, err := conn.QueryContext(context.TODO(), "select '2004-07-09'::DATE")
 	if err != nil {
 		t.Errorf("firebolt statement failed with %v", err)
 	}
 
-	dest := make([]driver.Value, 1)
+	var dest time.Time
 
-	if err = rows.Next(dest); err != nil {
+	assert(rows.Next(), true, t, "Next returned false")
+	if err = rows.Scan(&dest); err != nil {
 		t.Errorf("firebolt rows Next failed with %v", err)
 	}
-	if dest[0] != time.Date(2004, 7, 9, 0, 0, 0, 0, loc) {
-		t.Errorf("values are not equal: %v\n", dest[0])
+	if dest != time.Date(2004, 7, 9, 0, 0, 0, 0, loc) {
+		t.Errorf("values are not equal: %v\n", dest)
 	}
 }
 
 func TestConnectionQueryDecimalType(t *testing.T) {
-	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}, nil}
+	conn, err := sql.Open("firebolt", dsnMock)
+	if err != nil {
+		t.Errorf("opening a connection failed unexpectedly")
+		t.FailNow()
+	}
 
-	rows, err := conn.QueryContext(context.TODO(), "SELECT cast (123.23 as NUMERIC (12,6))", nil)
+	rows, err := conn.QueryContext(context.TODO(), "SELECT cast (123.23 as NUMERIC (12,6))")
 	if err != nil {
 		t.Errorf("firebolt statement failed with %v", err)
 	}
 
-	dest := make([]driver.Value, 1)
+	var dest float64
 
-	if err = rows.Next(dest); err != nil {
+	assert(rows.Next(), true, t, "Next returned false")
+	if err = rows.Scan(&dest); err != nil {
 		t.Errorf("firebolt rows Next failed with %v", err)
 	}
-	if dest[0] != 123.23 {
-		t.Errorf("values are not equal: %v\n", dest[0])
+	if dest != 123.23 {
+		t.Errorf("values are not equal: %v\n", dest)
 	}
 }
 
 func TestConnectionQueryDateTime64Type(t *testing.T) {
-	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}, nil}
+	conn, err := sql.Open("firebolt", dsnMock)
+	if err != nil {
+		t.Errorf("opening a connection failed unexpectedly")
+		t.FailNow()
+	}
 	loc, _ := time.LoadLocation("UTC")
 
-	rows, err := conn.QueryContext(context.TODO(), "SELECT '1980-01-01 02:03:04.321321'::TIMESTAMPNTZ;", nil)
+	rows, err := conn.QueryContext(context.TODO(), "SELECT '1980-01-01 02:03:04.321321'::TIMESTAMPNTZ;")
 	if err != nil {
 		t.Errorf("firebolt statement failed with %v", err)
 	}
 
-	dest := make([]driver.Value, 1)
+	var dest time.Time
 
-	if err = rows.Next(dest); err != nil {
+	assert(rows.Next(), true, t, "Next returned false")
+	if err = rows.Scan(&dest); err != nil {
 		t.Errorf("firebolt rows Next failed with %v", err)
 	}
-	if expected := time.Date(1980, 1, 1, 2, 3, 4, 321321000, loc); expected != dest[0] {
-		t.Errorf("values are not equal: %v and %v\n", dest[0], expected)
+	if expected := time.Date(1980, 1, 1, 2, 3, 4, 321321000, loc); expected != dest {
+		t.Errorf("values are not equal: %v and %v\n", dest, expected)
 	}
 }
 
 func TestConnectionQueryPGDateType(t *testing.T) {
-	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}, nil}
+	conn, err := sql.Open("firebolt", dsnMock)
+	if err != nil {
+		t.Errorf("opening a connection failed unexpectedly")
+		t.FailNow()
+	}
 	loc, _ := time.LoadLocation("UTC")
 
 	// Value 0001-01-01 is outside of range of regular DATE
-	rows, err := conn.QueryContext(context.TODO(), "SELECT '0001-01-01' :: PGDATE;", nil)
+	rows, err := conn.QueryContext(context.TODO(), "SELECT '0001-01-01' :: PGDATE;")
 	if err != nil {
 		t.Errorf("firebolt statement failed with %v", err)
 	}
 
-	dest := make([]driver.Value, 1)
+	var dest time.Time
 
-	if err = rows.Next(dest); err != nil {
+	assert(rows.Next(), true, t, "Next returned false")
+	if err = rows.Scan(&dest); err != nil {
 		t.Errorf("firebolt rows Next failed with %v", err)
 	}
-	if expected := time.Date(0001, 1, 1, 0, 0, 0, 0, loc); expected != dest[0] {
-		t.Errorf("values are not equal: %v and %v\n", dest[0], expected)
+	if expected := time.Date(0001, 1, 1, 0, 0, 0, 0, loc); expected != dest {
+		t.Errorf("values are not equal: %v and %v\n", dest, expected)
 	}
 }
 
 func TestConnectionQueryTimestampNTZType(t *testing.T) {
-	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}, nil}
+	conn, err := sql.Open("firebolt", dsnMock)
+	if err != nil {
+		t.Errorf("opening a connection failed unexpectedly")
+		t.FailNow()
+	}
 	loc, _ := time.LoadLocation("UTC")
 
-	rows, err := conn.QueryContext(context.TODO(), "SELECT '0001-01-05 17:04:42.123456' :: TIMESTAMPNTZ;", nil)
+	rows, err := conn.QueryContext(context.TODO(), "SELECT '0001-01-05 17:04:42.123456' :: TIMESTAMPNTZ;")
 	if err != nil {
 		t.Errorf("firebolt statement failed with %v", err)
 	}
 
-	dest := make([]driver.Value, 1)
+	var dest time.Time
 
-	if err = rows.Next(dest); err != nil {
+	assert(rows.Next(), true, t, "Next returned false")
+	if err = rows.Scan(&dest); err != nil {
 		t.Errorf("firebolt rows Next failed with %v", err)
 	}
-	if expected := time.Date(0001, 1, 5, 17, 4, 42, 123456000, loc); expected != dest[0] {
-		t.Errorf("values are not equal: %v and %v\n", dest[0], expected)
+	if expected := time.Date(0001, 1, 5, 17, 4, 42, 123456000, loc); expected != dest {
+		t.Errorf("values are not equal: %v and %v\n", dest, expected)
 	}
 }
 
 func TestConnectionQueryTimestampTZType(t *testing.T) {
-	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}, nil}
+	conn, err := sql.Open("firebolt", dsnMock)
+	if err != nil {
+		t.Errorf("opening a connection failed unexpectedly")
+		t.FailNow()
+	}
 	loc, _ := time.LoadLocation("UTC")
 
-	rows, err := conn.QueryContext(context.TODO(), "SELECT '2023-01-05 17:04:42.1234 Europe/Berlin'::TIMESTAMPTZ;", nil)
+	rows, err := conn.QueryContext(context.TODO(), "SELECT '2023-01-05 17:04:42.1234 Europe/Berlin'::TIMESTAMPTZ;")
 	if err != nil {
 		t.Errorf("firebolt statement failed with %v", err)
 	}
 
-	dest := make([]driver.Value, 1)
+	var dest time.Time
 
-	if err = rows.Next(dest); err != nil {
+	assert(rows.Next(), true, t, "Next returned false")
+	if err = rows.Scan(&dest); err != nil {
 		t.Errorf("firebolt rows Next failed with %v", err)
 	}
-	to_test, _ := dest[0].(time.Time)
 	// Expected offset by 1 hour when converted to UTC
 	expected := time.Date(2023, 1, 5, 16, 4, 42, 123400000, loc)
-	if !to_test.Equal(expected) {
-		t.Errorf("values are not equal Expected: %v Got: %v\n", expected, to_test)
+	if !dest.Equal(expected) {
+		t.Errorf("values are not equal Expected: %v Got: %v\n", expected, dest)
 	}
 }
 
 func TestConnectionQueryTimestampTZTypeAsia(t *testing.T) {
-	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"advanced_mode": "1", "time_zone": "Asia/Calcutta", "database": databaseMock}, nil}
+	conn, err := sql.Open("firebolt", dsnMock)
+	if err != nil {
+		t.Errorf("opening a connection failed unexpectedly")
+		t.FailNow()
+	}
+	if _, err = conn.ExecContext(context.Background(), "SET time_zone=Asia/Calcutta"); err != nil {
+		t.Errorf("firebolt statement failed with %v", err)
+		t.FailNow()
+	}
 	loc, _ := time.LoadLocation("Asia/Calcutta")
 
-	rows, err := conn.QueryContext(context.TODO(), "SELECT '2023-01-05 17:04:42.123456 Europe/Berlin'::TIMESTAMPTZ;", nil)
+	rows, err := conn.QueryContext(context.TODO(), "SELECT '2023-01-05 17:04:42.123456 Europe/Berlin'::TIMESTAMPTZ;")
 	if err != nil {
 		t.Errorf("firebolt statement failed with %v", err)
 	}
 
-	dest := make([]driver.Value, 1)
+	var dest time.Time
 
-	if err = rows.Next(dest); err != nil {
+	assert(rows.Next(), true, t, "Next returned false")
+	if err = rows.Scan(&dest); err != nil {
 		t.Errorf("firebolt rows Next failed with %v", err)
 	}
 	// Expected offset by 5:30 when converted to Asia/Calcutta
 	expected := time.Date(2023, 1, 5, 21, 34, 42, 123456000, loc)
-	to_test, _ := dest[0].(time.Time)
-	if !to_test.Equal(expected) {
-		t.Errorf("%s date with half-timezone check failed Expected: %s Got: %s", err, expected, to_test)
+	if !dest.Equal(expected) {
+		t.Errorf("%s date with half-timezone check failed Expected: %s Got: %s", err, expected, dest)
 	}
 }
 
 func TestConnectionMultipleStatement(t *testing.T) {
-	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}, nil}
-	if rows, err := conn.QueryContext(context.TODO(), "SELECT -1; SELECT -2", nil); err != nil {
+	conn, err := sql.Open("firebolt", dsnMock)
+	if err != nil {
+		t.Errorf("opening a connection failed unexpectedly")
+		t.FailNow()
+	}
+	if rows, err := conn.QueryContext(context.TODO(), "SELECT -1; SELECT -2"); err != nil {
 		t.Errorf("Query multistement returned err: %v", err)
 	} else {
-		dest := make([]driver.Value, 1)
 
-		err = rows.Next(dest)
-		assert(err, nil, t, "rows.Next returned an error")
-		assert(dest[0], int32(-1), t, "results are not equal")
+		var dest int32
 
-		if nextResultSet, ok := rows.(driver.RowsNextResultSet); !ok {
-			t.Errorf("multistatement didn't return RowsNextResultSet")
-		} else {
-			if !nextResultSet.HasNextResultSet() {
-				t.Errorf("HasNextResultSet returned false")
-			}
-			assert(nextResultSet.NextResultSet(), nil, t, "NextResultSet returned an error")
+		assert(rows.Next(), true, t, "Next returned false")
+		err = rows.Scan(&dest)
+		assert(err, nil, t, "rows.Scan returned an error")
+		assert(dest, int32(-1), t, "results are not equal")
 
-			err = rows.Next(dest)
-			assert(err, nil, t, "rows.Next returned an error")
-			assert(dest[0], int32(-2), t, "results are not equal")
+		assert(rows.NextResultSet(), true, t, "NextResultSet returned false")
+		assert(rows.Next(), true, t, "Next returned false")
+		err = rows.Scan(&dest)
+		assert(err, nil, t, "rows.Scan returned an error")
+		assert(dest, int32(-2), t, "results are not equal")
 
-			if nextResultSet.HasNextResultSet() {
-				t.Errorf("HasNextResultSet returned true")
-			}
-		}
+		assert(rows.NextResultSet(), false, t, "NextResultSet returned true")
+		assert(rows.Next(), false, t, "Next returned true")
 	}
 }
 
 func TestConnectionQueryBooleanType(t *testing.T) {
-	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}, nil}
+	conn, err := sql.Open("firebolt", dsnMock)
+	if err != nil {
+		t.Errorf("opening a connection failed unexpectedly")
+		t.FailNow()
+	}
 
-	rows, err := conn.QueryContext(context.TODO(), "SELECT true, false, null::boolean;", nil)
+	rows, err := conn.QueryContext(context.TODO(), "SELECT true, false, null::boolean;")
 	if err != nil {
 		t.Errorf("statement failed with %v", err)
 	}
 
-	dest := make([]driver.Value, 3)
+	var b1, b2 bool
+	// Nil value can only be assigned to an interface{}
+	var b3 interface{}
 
-	if err = rows.Next(dest); err != nil {
+	assert(rows.Next(), true, t, "Next returned false")
+	if err = rows.Scan(&b1, &b2, &b3); err != nil {
 		t.Errorf("firebolt rows Next failed with %v", err)
 	}
-	assert(dest[0], true, t, "results are not equal")
-	assert(dest[1], false, t, "results are not equal")
-	assert(dest[2], nil, t, "results are not equal")
+	assert(b1, true, t, "results are not equal")
+	assert(b2, false, t, "results are not equal")
+	assert(b3, nil, t, "results are not equal")
 }
 
 func TestConnectionQueryByteaType(t *testing.T) {
-	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}, nil}
+	conn, err := sql.Open("firebolt", dsnMock)
+	if err != nil {
+		t.Errorf("opening a connection failed unexpectedly")
+		t.FailNow()
+	}
 
-	rows, err := conn.QueryContext(context.TODO(), "SELECT 'abc123'::bytea", nil)
+	rows, err := conn.QueryContext(context.TODO(), "SELECT 'abc123'::bytea")
 	if err != nil {
 		t.Errorf("statement failed with %v", err)
 	}
 
-	dest := make([]driver.Value, 1)
+	var dest []byte
 
-	if err = rows.Next(dest); err != nil {
+	assert(rows.Next(), true, t, "Next returned false")
+	if err = rows.Scan(&dest); err != nil {
 		t.Errorf("firebolt rows Next failed with %v", err)
 	}
-	to_test, _ := dest[0].([]byte)
 	expected := []byte("abc123")
-	if !bytes.Equal(to_test, expected) {
-		t.Errorf("Bytea type check failed Expected: %s Got: %s", expected, to_test)
+	if !bytes.Equal(dest, expected) {
+		t.Errorf("Bytea type check failed Expected: %s Got: %s", expected, dest)
 	}
 }
 
 func TestConnectionPreparedStatement(t *testing.T) {
-	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}, nil}
+	conn, err := sql.Open("firebolt", dsnMock)
+	if err != nil {
+		t.Errorf("opening a connection failed unexpectedly")
+		t.FailNow()
+	}
 
-	_, err := conn.QueryContext(
+	_, err = conn.QueryContext(
 		context.Background(),
 		"DROP TABLE IF EXISTS test_prepared_statements",
-		nil,
 	)
 	if err != nil {
 		t.Errorf("drop table statement failed with %v", err)
@@ -306,7 +376,6 @@ func TestConnectionPreparedStatement(t *testing.T) {
 	_, err = conn.QueryContext(
 		context.Background(),
 		"CREATE TABLE test_prepared_statements (i INT, l LONG, f FLOAT, d DOUBLE, t TEXT, dt DATE, ts TIMESTAMP, tstz TIMESTAMPTZ, b BOOLEAN, ba BYTEA) PRIMARY INDEX i",
-		nil,
 	)
 	if err != nil {
 		t.Errorf("create table statement failed with %v", err)
@@ -323,18 +392,7 @@ func TestConnectionPreparedStatement(t *testing.T) {
 	_, err = conn.QueryContext(
 		context.Background(),
 		"INSERT INTO test_prepared_statements VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-		[]driver.NamedValue{
-			{Name: "i", Value: 1},
-			{Name: "l", Value: int64(2)},
-			{Name: "f", Value: 0.333333},
-			{Name: "dt", Value: 0.333333333333},
-			{Name: "t", Value: "text"},
-			{Name: "d", Value: d},
-			{Name: "ts", Value: ts},
-			{Name: "tstz", Value: tstz},
-			{Name: "b", Value: true},
-			{Name: "ba", Value: ba},
-		},
+		1, int64(2), 0.333333, 0.333333333333, "text", d, ts, tstz, true, ba,
 	)
 
 	if err != nil {
@@ -342,7 +400,7 @@ func TestConnectionPreparedStatement(t *testing.T) {
 		t.FailNow()
 	}
 
-	_, err = conn.QueryContext(context.Background(), "SET time_zone=Europe/Berlin", nil)
+	_, err = conn.QueryContext(context.Background(), "SET time_zone=Europe/Berlin")
 	if err != nil {
 		t.Errorf("set time_zone statement failed with %v", err)
 		t.FailNow()
@@ -351,7 +409,6 @@ func TestConnectionPreparedStatement(t *testing.T) {
 	rows, err := conn.QueryContext(
 		context.Background(),
 		"SELECT * FROM test_prepared_statements",
-		nil,
 	)
 	if err != nil {
 		t.Errorf("select statement failed with %v", err)
@@ -359,8 +416,13 @@ func TestConnectionPreparedStatement(t *testing.T) {
 	}
 
 	dest := make([]driver.Value, 10)
-	if err = rows.Next(dest); err != nil {
-		t.Errorf("firebolt rows Next failed with %v", err)
+	pointers := make([]interface{}, 10)
+	for i := range pointers {
+		pointers[i] = &dest[i]
+	}
+	assert(rows.Next(), true, t, "Next returned false")
+	if err = rows.Scan(pointers...); err != nil {
+		t.Errorf("firebolt rows Scan failed with %v", err)
 		t.FailNow()
 	}
 

--- a/connection_common_integration_test.go
+++ b/connection_common_integration_test.go
@@ -1,0 +1,391 @@
+//go:build integration || integration_v0
+// +build integration integration_v0
+
+package fireboltgosdk
+
+import (
+	"bytes"
+	"context"
+	"database/sql/driver"
+	"io"
+	"reflect"
+	"runtime/debug"
+	"testing"
+	"time"
+)
+
+// TestConnectionPrepareStatement, tests that prepare statement doesn't result into an error
+func TestConnectionSetStatement(t *testing.T) {
+	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}, nil}
+
+	_, err := conn.ExecContext(context.TODO(), "SET use_standard_sql=1", nil)
+	assert(err, nil, t, "set use_standard_sql returned an error, but shouldn't")
+
+	_, err = conn.QueryContext(context.TODO(), "SELECT * FROM information_schema.tables", nil)
+	assert(err, nil, t, "query returned an error, but shouldn't")
+
+}
+
+// TestConnectionQuery checks simple SELECT 1 exec
+func TestConnectionQueryWrong(t *testing.T) {
+	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}, nil}
+
+	if _, err := conn.ExecContext(context.TODO(), "SELECT wrong query", nil); err == nil {
+		t.Errorf("wrong statement didn't return an error")
+	}
+}
+
+// TestConnectionInsertQuery checks simple Insert works
+func TestConnectionInsertQuery(t *testing.T) {
+	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}, nil}
+	createTableSQL := "CREATE FACT TABLE integration_tests (id INT, name STRING) PRIMARY INDEX id"
+	deleteTableSQL := "DROP TABLE IF EXISTS integration_tests"
+	insertSQL := "INSERT INTO integration_tests (id, name) VALUES (0, 'some_text')"
+
+	if _, err := conn.ExecContext(context.TODO(), createTableSQL, nil); err != nil {
+		t.Errorf("statement returned an error: %v", err)
+	}
+	if _, err := conn.ExecContext(context.TODO(), "SET advanced_mode=1", nil); err != nil {
+		t.Errorf("statement returned an error: %v", err)
+	}
+	if _, err := conn.ExecContext(context.TODO(), insertSQL, nil); err != nil {
+		t.Errorf("statement returned an error: %v", err)
+	}
+	if _, err := conn.ExecContext(context.TODO(), deleteTableSQL, nil); err != nil {
+		t.Errorf("statement returned an error: %v", err)
+	}
+}
+
+// TestConnectionQuery checks simple SELECT query
+func TestConnectionQuery(t *testing.T) {
+	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}, nil}
+
+	sql := "SELECT -3213212 as \"const\", 2.3 as \"float\", 'some_text' as \"text\""
+	rows, err := conn.QueryContext(context.TODO(), sql, nil)
+	if err != nil {
+		t.Errorf("firebolt statement failed with %v", err)
+	}
+
+	columnNames := []string{"const", "float", "text"}
+	if !reflect.DeepEqual(rows.Columns(), columnNames) {
+		t.Errorf("column lists are not equal")
+	}
+
+	dest := make([]driver.Value, 3)
+	err = rows.Next(dest)
+	if err != nil {
+		t.Errorf("Next returned an error, but shouldn't")
+	}
+	assert(dest[0], int32(-3213212), t, "dest[0] is not equal")
+	assert(dest[1], float64(2.3), t, "dest[1] is not equal")
+	assert(dest[2], "some_text", t, "dest[2] is not equal")
+
+	assert(rows.Next(dest), io.EOF, t, "end of data didn't return io.EOF")
+}
+
+func TestConnectionQueryDate32Type(t *testing.T) {
+	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}, nil}
+	loc, _ := time.LoadLocation("UTC")
+
+	rows, err := conn.QueryContext(context.TODO(), "select '2004-07-09'::DATE", nil)
+	if err != nil {
+		t.Errorf("firebolt statement failed with %v", err)
+	}
+
+	dest := make([]driver.Value, 1)
+
+	if err = rows.Next(dest); err != nil {
+		t.Errorf("firebolt rows Next failed with %v", err)
+	}
+	if dest[0] != time.Date(2004, 7, 9, 0, 0, 0, 0, loc) {
+		t.Errorf("values are not equal: %v\n", dest[0])
+	}
+}
+
+func TestConnectionQueryDecimalType(t *testing.T) {
+	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}, nil}
+
+	rows, err := conn.QueryContext(context.TODO(), "SELECT cast (123.23 as NUMERIC (12,6))", nil)
+	if err != nil {
+		t.Errorf("firebolt statement failed with %v", err)
+	}
+
+	dest := make([]driver.Value, 1)
+
+	if err = rows.Next(dest); err != nil {
+		t.Errorf("firebolt rows Next failed with %v", err)
+	}
+	if dest[0] != 123.23 {
+		t.Errorf("values are not equal: %v\n", dest[0])
+	}
+}
+
+func TestConnectionQueryDateTime64Type(t *testing.T) {
+	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}, nil}
+	loc, _ := time.LoadLocation("UTC")
+
+	rows, err := conn.QueryContext(context.TODO(), "SELECT '1980-01-01 02:03:04.321321'::TIMESTAMPNTZ;", nil)
+	if err != nil {
+		t.Errorf("firebolt statement failed with %v", err)
+	}
+
+	dest := make([]driver.Value, 1)
+
+	if err = rows.Next(dest); err != nil {
+		t.Errorf("firebolt rows Next failed with %v", err)
+	}
+	if expected := time.Date(1980, 1, 1, 2, 3, 4, 321321000, loc); expected != dest[0] {
+		t.Errorf("values are not equal: %v and %v\n", dest[0], expected)
+	}
+}
+
+func TestConnectionQueryPGDateType(t *testing.T) {
+	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}, nil}
+	loc, _ := time.LoadLocation("UTC")
+
+	// Value 0001-01-01 is outside of range of regular DATE
+	rows, err := conn.QueryContext(context.TODO(), "SELECT '0001-01-01' :: PGDATE;", nil)
+	if err != nil {
+		t.Errorf("firebolt statement failed with %v", err)
+	}
+
+	dest := make([]driver.Value, 1)
+
+	if err = rows.Next(dest); err != nil {
+		t.Errorf("firebolt rows Next failed with %v", err)
+	}
+	if expected := time.Date(0001, 1, 1, 0, 0, 0, 0, loc); expected != dest[0] {
+		t.Errorf("values are not equal: %v and %v\n", dest[0], expected)
+	}
+}
+
+func TestConnectionQueryTimestampNTZType(t *testing.T) {
+	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}, nil}
+	loc, _ := time.LoadLocation("UTC")
+
+	rows, err := conn.QueryContext(context.TODO(), "SELECT '0001-01-05 17:04:42.123456' :: TIMESTAMPNTZ;", nil)
+	if err != nil {
+		t.Errorf("firebolt statement failed with %v", err)
+	}
+
+	dest := make([]driver.Value, 1)
+
+	if err = rows.Next(dest); err != nil {
+		t.Errorf("firebolt rows Next failed with %v", err)
+	}
+	if expected := time.Date(0001, 1, 5, 17, 4, 42, 123456000, loc); expected != dest[0] {
+		t.Errorf("values are not equal: %v and %v\n", dest[0], expected)
+	}
+}
+
+func TestConnectionQueryTimestampTZType(t *testing.T) {
+	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}, nil}
+	loc, _ := time.LoadLocation("UTC")
+
+	rows, err := conn.QueryContext(context.TODO(), "SELECT '2023-01-05 17:04:42.1234 Europe/Berlin'::TIMESTAMPTZ;", nil)
+	if err != nil {
+		t.Errorf("firebolt statement failed with %v", err)
+	}
+
+	dest := make([]driver.Value, 1)
+
+	if err = rows.Next(dest); err != nil {
+		t.Errorf("firebolt rows Next failed with %v", err)
+	}
+	to_test, _ := dest[0].(time.Time)
+	// Expected offset by 1 hour when converted to UTC
+	expected := time.Date(2023, 1, 5, 16, 4, 42, 123400000, loc)
+	if !to_test.Equal(expected) {
+		t.Errorf("values are not equal Expected: %v Got: %v\n", expected, to_test)
+	}
+}
+
+func TestConnectionQueryTimestampTZTypeAsia(t *testing.T) {
+	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"advanced_mode": "1", "time_zone": "Asia/Calcutta", "database": databaseMock}, nil}
+	loc, _ := time.LoadLocation("Asia/Calcutta")
+
+	rows, err := conn.QueryContext(context.TODO(), "SELECT '2023-01-05 17:04:42.123456 Europe/Berlin'::TIMESTAMPTZ;", nil)
+	if err != nil {
+		t.Errorf("firebolt statement failed with %v", err)
+	}
+
+	dest := make([]driver.Value, 1)
+
+	if err = rows.Next(dest); err != nil {
+		t.Errorf("firebolt rows Next failed with %v", err)
+	}
+	// Expected offset by 5:30 when converted to Asia/Calcutta
+	expected := time.Date(2023, 1, 5, 21, 34, 42, 123456000, loc)
+	to_test, _ := dest[0].(time.Time)
+	if !to_test.Equal(expected) {
+		t.Errorf("%s date with half-timezone check failed Expected: %s Got: %s", err, expected, to_test)
+	}
+}
+
+func TestConnectionMultipleStatement(t *testing.T) {
+	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}, nil}
+	if rows, err := conn.QueryContext(context.TODO(), "SELECT -1; SELECT -2", nil); err != nil {
+		t.Errorf("Query multistement returned err: %v", err)
+	} else {
+		dest := make([]driver.Value, 1)
+
+		err = rows.Next(dest)
+		assert(err, nil, t, "rows.Next returned an error")
+		assert(dest[0], int32(-1), t, "results are not equal")
+
+		if nextResultSet, ok := rows.(driver.RowsNextResultSet); !ok {
+			t.Errorf("multistatement didn't return RowsNextResultSet")
+		} else {
+			if !nextResultSet.HasNextResultSet() {
+				t.Errorf("HasNextResultSet returned false")
+			}
+			assert(nextResultSet.NextResultSet(), nil, t, "NextResultSet returned an error")
+
+			err = rows.Next(dest)
+			assert(err, nil, t, "rows.Next returned an error")
+			assert(dest[0], int32(-2), t, "results are not equal")
+
+			if nextResultSet.HasNextResultSet() {
+				t.Errorf("HasNextResultSet returned true")
+			}
+		}
+	}
+}
+
+func TestConnectionQueryBooleanType(t *testing.T) {
+	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}, nil}
+
+	rows, err := conn.QueryContext(context.TODO(), "SELECT true, false, null::boolean;", nil)
+	if err != nil {
+		t.Errorf("statement failed with %v", err)
+	}
+
+	dest := make([]driver.Value, 3)
+
+	if err = rows.Next(dest); err != nil {
+		t.Errorf("firebolt rows Next failed with %v", err)
+	}
+	assert(dest[0], true, t, "results are not equal")
+	assert(dest[1], false, t, "results are not equal")
+	assert(dest[2], nil, t, "results are not equal")
+}
+
+func TestConnectionQueryByteaType(t *testing.T) {
+	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}, nil}
+
+	rows, err := conn.QueryContext(context.TODO(), "SELECT 'abc123'::bytea", nil)
+	if err != nil {
+		t.Errorf("statement failed with %v", err)
+	}
+
+	dest := make([]driver.Value, 1)
+
+	if err = rows.Next(dest); err != nil {
+		t.Errorf("firebolt rows Next failed with %v", err)
+	}
+	to_test, _ := dest[0].([]byte)
+	expected := []byte("abc123")
+	if !bytes.Equal(to_test, expected) {
+		t.Errorf("Bytea type check failed Expected: %s Got: %s", expected, to_test)
+	}
+}
+
+func TestConnectionPreparedStatement(t *testing.T) {
+	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}, nil}
+
+	_, err := conn.QueryContext(
+		context.Background(),
+		"DROP TABLE IF EXISTS test_prepared_statements",
+		nil,
+	)
+	if err != nil {
+		t.Errorf("drop table statement failed with %v", err)
+		t.FailNow()
+	}
+
+	_, err = conn.QueryContext(
+		context.Background(),
+		"CREATE TABLE test_prepared_statements (i INT, l LONG, f FLOAT, d DOUBLE, t TEXT, dt DATE, ts TIMESTAMP, tstz TIMESTAMPTZ, b BOOLEAN, ba BYTEA) PRIMARY INDEX i",
+		nil,
+	)
+	if err != nil {
+		t.Errorf("create table statement failed with %v", err)
+		t.FailNow()
+	}
+
+	loc, _ := time.LoadLocation("Europe/Berlin")
+
+	d := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	ts := time.Date(2021, 1, 1, 2, 10, 20, 3000, time.UTC)
+	tstz := time.Date(2021, 1, 1, 2, 10, 20, 3000, loc)
+	ba := []byte("abc123")
+
+	_, err = conn.QueryContext(
+		context.Background(),
+		"INSERT INTO test_prepared_statements VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+		[]driver.NamedValue{
+			{Name: "i", Value: 1},
+			{Name: "l", Value: int64(2)},
+			{Name: "f", Value: 0.333333},
+			{Name: "dt", Value: 0.333333333333},
+			{Name: "t", Value: "text"},
+			{Name: "d", Value: d},
+			{Name: "ts", Value: ts},
+			{Name: "tstz", Value: tstz},
+			{Name: "b", Value: true},
+			{Name: "ba", Value: ba},
+		},
+	)
+
+	if err != nil {
+		t.Errorf("insert statement failed with %v", err)
+		t.FailNow()
+	}
+
+	_, err = conn.QueryContext(context.Background(), "SET time_zone=Europe/Berlin", nil)
+	if err != nil {
+		t.Errorf("set time_zone statement failed with %v", err)
+		t.FailNow()
+	}
+
+	rows, err := conn.QueryContext(
+		context.Background(),
+		"SELECT * FROM test_prepared_statements",
+		nil,
+	)
+	if err != nil {
+		t.Errorf("select statement failed with %v", err)
+		t.FailNow()
+	}
+
+	dest := make([]driver.Value, 10)
+	if err = rows.Next(dest); err != nil {
+		t.Errorf("firebolt rows Next failed with %v", err)
+		t.FailNow()
+	}
+
+	assert(dest[0], int32(1), t, "int32 results are not equal")
+	assert(dest[1], int64(2), t, "int64 results are not equal")
+	assert(dest[2], float32(0.333333), t, "float32 results are not equal")
+	assert(dest[3], 0.333333333333, t, "float64 results are not equal")
+	assert(dest[4], "text", t, "string results are not equal")
+	assert(dest[5], d, t, "date results are not equal")
+	assert(dest[6], ts.UTC(), t, "timestamp results are not equal")
+	// Use .Equal to correctly compare timezones
+	if !dest[7].(time.Time).Equal(tstz) {
+		t.Errorf("timestamptz results are not equal Expected: %s Got: %s", tstz, dest[7])
+	}
+	assert(dest[8], true, t, "boolean results are not equal")
+	baValue := dest[9].([]byte)
+	if len(baValue) != len(ba) {
+		t.Log(string(debug.Stack()))
+		t.Errorf("bytea results are not equal Expected length: %d Got: %d", len(ba), len(baValue))
+	}
+	for i := range ba {
+		if ba[i] != baValue[i] {
+			t.Log(string(debug.Stack()))
+			t.Errorf("bytea results are not equal Expected: %s Got: %s", ba, baValue)
+			break
+		}
+	}
+}

--- a/connection_integration_test.go
+++ b/connection_integration_test.go
@@ -13,6 +13,7 @@ func TestConnectionUseDatabase(t *testing.T) {
 	tableName := "test_use_database"
 	createTableSQL := "CREATE TABLE IF NOT EXISTS " + tableName + " (id INT)"
 	selectTableSQL := "SELECT table_name FROM information_schema.tables WHERE table_name = ?"
+	useDatabaseSQL := "USE DATABASE "
 	newDatabaseName := databaseMock + "_new"
 
 	conn, err := sql.Open("firebolt", dsnSystemEngineMock)
@@ -21,7 +22,7 @@ func TestConnectionUseDatabase(t *testing.T) {
 		t.FailNow()
 	}
 
-	_, err = conn.ExecContext(context.Background(), "USE DATABASE "+databaseMock)
+	_, err = conn.ExecContext(context.Background(), useDatabaseSQL+databaseMock)
 	if err != nil {
 		t.Errorf("use database statement failed with %v", err)
 		t.FailNow()
@@ -32,7 +33,7 @@ func TestConnectionUseDatabase(t *testing.T) {
 		t.Errorf("create table statement failed with %v", err)
 		t.FailNow()
 	}
-	defer conn.Exec("USE DATABASE " + databaseMock + "; DROP TABLE " + tableName)
+	defer conn.Exec(useDatabaseSQL + databaseMock + "; DROP TABLE " + tableName)
 
 	rows, err := conn.QueryContext(context.Background(), selectTableSQL, tableName)
 	if err != nil {
@@ -49,9 +50,9 @@ func TestConnectionUseDatabase(t *testing.T) {
 		t.Errorf("create database statement failed with %v", err)
 		t.FailNow()
 	}
-	defer conn.Exec("USE DATABASE " + databaseMock + "; DROP DATABASE " + newDatabaseName)
+	defer conn.Exec(useDatabaseSQL + databaseMock + "; DROP DATABASE " + newDatabaseName)
 
-	_, err = conn.ExecContext(context.Background(), "USE DATABASE "+newDatabaseName)
+	_, err = conn.ExecContext(context.Background(), useDatabaseSQL+newDatabaseName)
 	if err != nil {
 		t.Errorf("use database statement failed with %v", err)
 		t.FailNow()

--- a/connection_integration_test.go
+++ b/connection_integration_test.go
@@ -1,388 +1,69 @@
-//go:build integration || integration_v0
-// +build integration integration_v0
+//go:build integration
+// +build integration
 
 package fireboltgosdk
 
 import (
-	"bytes"
 	"context"
-	"database/sql/driver"
-	"io"
-	"reflect"
-	"runtime/debug"
+	"database/sql"
 	"testing"
-	"time"
 )
 
-// TestConnectionPrepareStatement, tests that prepare statement doesn't result into an error
-func TestConnectionSetStatement(t *testing.T) {
-	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}}
+func TestConnectionUseDatabase(t *testing.T) {
+	tableName := "test_use_database"
+	createTableSQL := "CREATE TABLE IF NOT EXISTS " + tableName + " (id INT)"
+	selectTableSQL := "SELECT table_name FROM information_schema.tables WHERE table_name = ?"
+	newDatabaseName := databaseMock + "_new"
 
-	_, err := conn.ExecContext(context.TODO(), "SET use_standard_sql=1", nil)
-	assert(err, nil, t, "set use_standard_sql returned an error, but shouldn't")
-
-	_, err = conn.QueryContext(context.TODO(), "SELECT * FROM information_schema.tables", nil)
-	assert(err, nil, t, "query returned an error, but shouldn't")
-
-}
-
-// TestConnectionQuery checks simple SELECT 1 exec
-func TestConnectionQueryWrong(t *testing.T) {
-	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}}
-
-	if _, err := conn.ExecContext(context.TODO(), "SELECT wrong query", nil); err == nil {
-		t.Errorf("wrong statement didn't return an error")
-	}
-}
-
-// TestConnectionInsertQuery checks simple Insert works
-func TestConnectionInsertQuery(t *testing.T) {
-	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}}
-	createTableSQL := "CREATE FACT TABLE integration_tests (id INT, name STRING) PRIMARY INDEX id"
-	deleteTableSQL := "DROP TABLE IF EXISTS integration_tests"
-	insertSQL := "INSERT INTO integration_tests (id, name) VALUES (0, 'some_text')"
-
-	if _, err := conn.ExecContext(context.TODO(), createTableSQL, nil); err != nil {
-		t.Errorf("statement returned an error: %v", err)
-	}
-	if _, err := conn.ExecContext(context.TODO(), insertSQL, nil); err != nil {
-		t.Errorf("statement returned an error: %v", err)
-	}
-	if _, err := conn.ExecContext(context.TODO(), deleteTableSQL, nil); err != nil {
-		t.Errorf("statement returned an error: %v", err)
-	}
-}
-
-// TestConnectionQuery checks simple SELECT query
-func TestConnectionQuery(t *testing.T) {
-	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}}
-
-	sql := "SELECT -3213212 as \"const\", 2.3 as \"float\", 'some_text' as \"text\""
-	rows, err := conn.QueryContext(context.TODO(), sql, nil)
+	conn, err := sql.Open("firebolt", dsnSystemEngineMock)
 	if err != nil {
-		t.Errorf("firebolt statement failed with %v", err)
-	}
-
-	columnNames := []string{"const", "float", "text"}
-	if !reflect.DeepEqual(rows.Columns(), columnNames) {
-		t.Errorf("column lists are not equal")
-	}
-
-	dest := make([]driver.Value, 3)
-	err = rows.Next(dest)
-	if err != nil {
-		t.Errorf("Next returned an error, but shouldn't")
-	}
-	assert(dest[0], int32(-3213212), t, "dest[0] is not equal")
-	assert(dest[1], float64(2.3), t, "dest[1] is not equal")
-	assert(dest[2], "some_text", t, "dest[2] is not equal")
-
-	assert(rows.Next(dest), io.EOF, t, "end of data didn't return io.EOF")
-}
-
-func TestConnectionQueryDate32Type(t *testing.T) {
-	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}}
-	loc, _ := time.LoadLocation("UTC")
-
-	rows, err := conn.QueryContext(context.TODO(), "select '2004-07-09'::DATE", nil)
-	if err != nil {
-		t.Errorf("firebolt statement failed with %v", err)
-	}
-
-	dest := make([]driver.Value, 1)
-
-	if err = rows.Next(dest); err != nil {
-		t.Errorf("firebolt rows Next failed with %v", err)
-	}
-	if dest[0] != time.Date(2004, 7, 9, 0, 0, 0, 0, loc) {
-		t.Errorf("values are not equal: %v\n", dest[0])
-	}
-}
-
-func TestConnectionQueryDecimalType(t *testing.T) {
-	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}}
-
-	rows, err := conn.QueryContext(context.TODO(), "SELECT cast (123.23 as NUMERIC (12,6))", nil)
-	if err != nil {
-		t.Errorf("firebolt statement failed with %v", err)
-	}
-
-	dest := make([]driver.Value, 1)
-
-	if err = rows.Next(dest); err != nil {
-		t.Errorf("firebolt rows Next failed with %v", err)
-	}
-	if dest[0] != 123.23 {
-		t.Errorf("values are not equal: %v\n", dest[0])
-	}
-}
-
-func TestConnectionQueryDateTime64Type(t *testing.T) {
-	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}}
-	loc, _ := time.LoadLocation("UTC")
-
-	rows, err := conn.QueryContext(context.TODO(), "SELECT '1980-01-01 02:03:04.321321'::TIMESTAMPNTZ;", nil)
-	if err != nil {
-		t.Errorf("firebolt statement failed with %v", err)
-	}
-
-	dest := make([]driver.Value, 1)
-
-	if err = rows.Next(dest); err != nil {
-		t.Errorf("firebolt rows Next failed with %v", err)
-	}
-	if expected := time.Date(1980, 1, 1, 2, 3, 4, 321321000, loc); expected != dest[0] {
-		t.Errorf("values are not equal: %v and %v\n", dest[0], expected)
-	}
-}
-
-func TestConnectionQueryPGDateType(t *testing.T) {
-	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}}
-	loc, _ := time.LoadLocation("UTC")
-
-	// Value 0001-01-01 is outside of range of regular DATE
-	rows, err := conn.QueryContext(context.TODO(), "SELECT '0001-01-01' :: PGDATE;", nil)
-	if err != nil {
-		t.Errorf("firebolt statement failed with %v", err)
-	}
-
-	dest := make([]driver.Value, 1)
-
-	if err = rows.Next(dest); err != nil {
-		t.Errorf("firebolt rows Next failed with %v", err)
-	}
-	if expected := time.Date(0001, 1, 1, 0, 0, 0, 0, loc); expected != dest[0] {
-		t.Errorf("values are not equal: %v and %v\n", dest[0], expected)
-	}
-}
-
-func TestConnectionQueryTimestampNTZType(t *testing.T) {
-	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}}
-	loc, _ := time.LoadLocation("UTC")
-
-	rows, err := conn.QueryContext(context.TODO(), "SELECT '0001-01-05 17:04:42.123456' :: TIMESTAMPNTZ;", nil)
-	if err != nil {
-		t.Errorf("firebolt statement failed with %v", err)
-	}
-
-	dest := make([]driver.Value, 1)
-
-	if err = rows.Next(dest); err != nil {
-		t.Errorf("firebolt rows Next failed with %v", err)
-	}
-	if expected := time.Date(0001, 1, 5, 17, 4, 42, 123456000, loc); expected != dest[0] {
-		t.Errorf("values are not equal: %v and %v\n", dest[0], expected)
-	}
-}
-
-func TestConnectionQueryTimestampTZType(t *testing.T) {
-	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}}
-	loc, _ := time.LoadLocation("UTC")
-
-	rows, err := conn.QueryContext(context.TODO(), "SELECT '2023-01-05 17:04:42.1234 Europe/Berlin'::TIMESTAMPTZ;", nil)
-	if err != nil {
-		t.Errorf("firebolt statement failed with %v", err)
-	}
-
-	dest := make([]driver.Value, 1)
-
-	if err = rows.Next(dest); err != nil {
-		t.Errorf("firebolt rows Next failed with %v", err)
-	}
-	to_test, _ := dest[0].(time.Time)
-	// Expected offset by 1 hour when converted to UTC
-	expected := time.Date(2023, 1, 5, 16, 4, 42, 123400000, loc)
-	if !to_test.Equal(expected) {
-		t.Errorf("values are not equal Expected: %v Got: %v\n", expected, to_test)
-	}
-}
-
-func TestConnectionQueryTimestampTZTypeAsia(t *testing.T) {
-	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"time_zone": "Asia/Calcutta", "database": databaseMock}}
-	loc, _ := time.LoadLocation("Asia/Calcutta")
-
-	rows, err := conn.QueryContext(context.TODO(), "SELECT '2023-01-05 17:04:42.123456 Europe/Berlin'::TIMESTAMPTZ;", nil)
-	if err != nil {
-		t.Errorf("firebolt statement failed with %v", err)
-	}
-
-	dest := make([]driver.Value, 1)
-
-	if err = rows.Next(dest); err != nil {
-		t.Errorf("firebolt rows Next failed with %v", err)
-	}
-	// Expected offset by 5:30 when converted to Asia/Calcutta
-	expected := time.Date(2023, 1, 5, 21, 34, 42, 123456000, loc)
-	to_test, _ := dest[0].(time.Time)
-	if !to_test.Equal(expected) {
-		t.Errorf("%s date with half-timezone check failed Expected: %s Got: %s", err, expected, to_test)
-	}
-}
-
-func TestConnectionMultipleStatement(t *testing.T) {
-	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}}
-	if rows, err := conn.QueryContext(context.TODO(), "SELECT -1; SELECT -2", nil); err != nil {
-		t.Errorf("Query multistement returned err: %v", err)
-	} else {
-		dest := make([]driver.Value, 1)
-
-		err = rows.Next(dest)
-		assert(err, nil, t, "rows.Next returned an error")
-		assert(dest[0], int32(-1), t, "results are not equal")
-
-		if nextResultSet, ok := rows.(driver.RowsNextResultSet); !ok {
-			t.Errorf("multistatement didn't return RowsNextResultSet")
-		} else {
-			if !nextResultSet.HasNextResultSet() {
-				t.Errorf("HasNextResultSet returned false")
-			}
-			assert(nextResultSet.NextResultSet(), nil, t, "NextResultSet returned an error")
-
-			err = rows.Next(dest)
-			assert(err, nil, t, "rows.Next returned an error")
-			assert(dest[0], int32(-2), t, "results are not equal")
-
-			if nextResultSet.HasNextResultSet() {
-				t.Errorf("HasNextResultSet returned true")
-			}
-		}
-	}
-}
-
-func TestConnectionQueryBooleanType(t *testing.T) {
-	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}}
-
-	rows, err := conn.QueryContext(context.TODO(), "SELECT true, false, null::boolean;", nil)
-	if err != nil {
-		t.Errorf("statement failed with %v", err)
-	}
-
-	dest := make([]driver.Value, 3)
-
-	if err = rows.Next(dest); err != nil {
-		t.Errorf("firebolt rows Next failed with %v", err)
-	}
-	assert(dest[0], true, t, "results are not equal")
-	assert(dest[1], false, t, "results are not equal")
-	assert(dest[2], nil, t, "results are not equal")
-}
-
-func TestConnectionQueryByteaType(t *testing.T) {
-	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}}
-
-	rows, err := conn.QueryContext(context.TODO(), "SELECT 'abc123'::bytea", nil)
-	if err != nil {
-		t.Errorf("statement failed with %v", err)
-	}
-
-	dest := make([]driver.Value, 1)
-
-	if err = rows.Next(dest); err != nil {
-		t.Errorf("firebolt rows Next failed with %v", err)
-	}
-	to_test, _ := dest[0].([]byte)
-	expected := []byte("abc123")
-	if !bytes.Equal(to_test, expected) {
-		t.Errorf("Bytea type check failed Expected: %s Got: %s", expected, to_test)
-	}
-}
-
-func TestConnectionPreparedStatement(t *testing.T) {
-	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}}
-
-	_, err := conn.QueryContext(
-		context.Background(),
-		"DROP TABLE IF EXISTS test_prepared_statements",
-		nil,
-	)
-	if err != nil {
-		t.Errorf("drop table statement failed with %v", err)
+		t.Errorf("opening a connection failed unexpectedly")
 		t.FailNow()
 	}
 
-	_, err = conn.QueryContext(
-		context.Background(),
-		"CREATE TABLE test_prepared_statements (i INT, l LONG, f FLOAT, d DOUBLE, t TEXT, dt DATE, ts TIMESTAMP, tstz TIMESTAMPTZ, b BOOLEAN, ba BYTEA) PRIMARY INDEX i",
-		nil,
-	)
+	_, err = conn.ExecContext(context.Background(), "USE DATABASE "+databaseMock)
+	if err != nil {
+		t.Errorf("use database statement failed with %v", err)
+		t.FailNow()
+	}
+
+	_, err = conn.ExecContext(context.Background(), createTableSQL)
 	if err != nil {
 		t.Errorf("create table statement failed with %v", err)
 		t.FailNow()
 	}
+	defer conn.Exec("USE DATABASE " + databaseMock + "; DROP TABLE " + tableName)
 
-	loc, _ := time.LoadLocation("Europe/Berlin")
-
-	d := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
-	ts := time.Date(2021, 1, 1, 2, 10, 20, 3000, time.UTC)
-	tstz := time.Date(2021, 1, 1, 2, 10, 20, 3000, loc)
-	ba := []byte("abc123")
-
-	_, err = conn.QueryContext(
-		context.Background(),
-		"INSERT INTO test_prepared_statements VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-		[]driver.NamedValue{
-			{Name: "i", Value: 1},
-			{Name: "l", Value: int64(2)},
-			{Name: "f", Value: 0.333333},
-			{Name: "dt", Value: 0.333333333333},
-			{Name: "t", Value: "text"},
-			{Name: "d", Value: d},
-			{Name: "ts", Value: ts},
-			{Name: "tstz", Value: tstz},
-			{Name: "b", Value: true},
-			{Name: "ba", Value: ba},
-		},
-	)
-
-	if err != nil {
-		t.Errorf("insert statement failed with %v", err)
-		t.FailNow()
-	}
-
-	_, err = conn.QueryContext(context.Background(), "SET time_zone=Europe/Berlin", nil)
-	if err != nil {
-		t.Errorf("set time_zone statement failed with %v", err)
-		t.FailNow()
-	}
-
-	rows, err := conn.QueryContext(
-		context.Background(),
-		"SELECT * FROM test_prepared_statements",
-		nil,
-	)
+	rows, err := conn.QueryContext(context.Background(), selectTableSQL, tableName)
 	if err != nil {
 		t.Errorf("select statement failed with %v", err)
 		t.FailNow()
 	}
-
-	dest := make([]driver.Value, 10)
-	if err = rows.Next(dest); err != nil {
-		t.Errorf("firebolt rows Next failed with %v", err)
+	if !rows.Next() {
+		t.Errorf("table %s wasn't created", tableName)
 		t.FailNow()
 	}
 
-	assert(dest[0], int32(1), t, "int32 results are not equal")
-	assert(dest[1], int64(2), t, "int64 results are not equal")
-	assert(dest[2], float32(0.333333), t, "float32 results are not equal")
-	assert(dest[3], 0.333333333333, t, "float64 results are not equal")
-	assert(dest[4], "text", t, "string results are not equal")
-	assert(dest[5], d, t, "date results are not equal")
-	assert(dest[6], ts.UTC(), t, "timestamp results are not equal")
-	// Use .Equal to correctly compare timezones
-	if !dest[7].(time.Time).Equal(tstz) {
-		t.Errorf("timestamptz results are not equal Expected: %s Got: %s", tstz, dest[7])
+	_, err = conn.ExecContext(context.Background(), "CREATE DATABASE IF NOT EXISTS "+newDatabaseName)
+	if err != nil {
+		t.Errorf("create database statement failed with %v", err)
+		t.FailNow()
 	}
-	assert(dest[8], true, t, "boolean results are not equal")
-	baValue := dest[9].([]byte)
-	if len(baValue) != len(ba) {
-		t.Log(string(debug.Stack()))
-		t.Errorf("bytea results are not equal Expected length: %d Got: %d", len(ba), len(baValue))
+	defer conn.Exec("USE DATABASE " + databaseMock + "; DROP DATABASE " + newDatabaseName)
+
+	_, err = conn.ExecContext(context.Background(), "USE DATABASE "+newDatabaseName)
+	if err != nil {
+		t.Errorf("use database statement failed with %v", err)
+		t.FailNow()
 	}
-	for i := range ba {
-		if ba[i] != baValue[i] {
-			t.Log(string(debug.Stack()))
-			t.Errorf("bytea results are not equal Expected: %s Got: %s", ba, baValue)
-			break
-		}
+
+	rows, err = conn.QueryContext(context.Background(), selectTableSQL, tableName)
+	if err != nil {
+		t.Errorf("select statement failed with %v", err)
+		t.FailNow()
+	}
+	if rows.Next() {
+		t.Errorf("use database statement didn't update the database")
+		t.FailNow()
 	}
 }

--- a/connection_integration_test.go
+++ b/connection_integration_test.go
@@ -16,7 +16,7 @@ import (
 
 // TestConnectionPrepareStatement, tests that prepare statement doesn't result into an error
 func TestConnectionSetStatement(t *testing.T) {
-	conn := fireboltConnection{clientMock, databaseMock, engineUrlMock, map[string]string{}}
+	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}}
 
 	_, err := conn.ExecContext(context.TODO(), "SET use_standard_sql=1", nil)
 	assert(err, nil, t, "set use_standard_sql returned an error, but shouldn't")
@@ -28,7 +28,7 @@ func TestConnectionSetStatement(t *testing.T) {
 
 // TestConnectionQuery checks simple SELECT 1 exec
 func TestConnectionQueryWrong(t *testing.T) {
-	conn := fireboltConnection{clientMock, databaseMock, engineUrlMock, map[string]string{}}
+	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}}
 
 	if _, err := conn.ExecContext(context.TODO(), "SELECT wrong query", nil); err == nil {
 		t.Errorf("wrong statement didn't return an error")
@@ -37,7 +37,7 @@ func TestConnectionQueryWrong(t *testing.T) {
 
 // TestConnectionInsertQuery checks simple Insert works
 func TestConnectionInsertQuery(t *testing.T) {
-	conn := fireboltConnection{clientMock, databaseMock, engineUrlMock, map[string]string{}}
+	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}}
 	createTableSQL := "CREATE FACT TABLE integration_tests (id INT, name STRING) PRIMARY INDEX id"
 	deleteTableSQL := "DROP TABLE IF EXISTS integration_tests"
 	insertSQL := "INSERT INTO integration_tests (id, name) VALUES (0, 'some_text')"
@@ -55,7 +55,7 @@ func TestConnectionInsertQuery(t *testing.T) {
 
 // TestConnectionQuery checks simple SELECT query
 func TestConnectionQuery(t *testing.T) {
-	conn := fireboltConnection{clientMock, databaseMock, engineUrlMock, map[string]string{}}
+	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}}
 
 	sql := "SELECT -3213212 as \"const\", 2.3 as \"float\", 'some_text' as \"text\""
 	rows, err := conn.QueryContext(context.TODO(), sql, nil)
@@ -81,7 +81,7 @@ func TestConnectionQuery(t *testing.T) {
 }
 
 func TestConnectionQueryDate32Type(t *testing.T) {
-	conn := fireboltConnection{clientMock, databaseMock, engineUrlMock, map[string]string{}}
+	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}}
 	loc, _ := time.LoadLocation("UTC")
 
 	rows, err := conn.QueryContext(context.TODO(), "select '2004-07-09'::DATE", nil)
@@ -100,7 +100,7 @@ func TestConnectionQueryDate32Type(t *testing.T) {
 }
 
 func TestConnectionQueryDecimalType(t *testing.T) {
-	conn := fireboltConnection{clientMock, databaseMock, engineUrlMock, map[string]string{}}
+	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}}
 
 	rows, err := conn.QueryContext(context.TODO(), "SELECT cast (123.23 as NUMERIC (12,6))", nil)
 	if err != nil {
@@ -118,7 +118,7 @@ func TestConnectionQueryDecimalType(t *testing.T) {
 }
 
 func TestConnectionQueryDateTime64Type(t *testing.T) {
-	conn := fireboltConnection{clientMock, databaseMock, engineUrlMock, map[string]string{}}
+	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}}
 	loc, _ := time.LoadLocation("UTC")
 
 	rows, err := conn.QueryContext(context.TODO(), "SELECT '1980-01-01 02:03:04.321321'::TIMESTAMPNTZ;", nil)
@@ -137,7 +137,7 @@ func TestConnectionQueryDateTime64Type(t *testing.T) {
 }
 
 func TestConnectionQueryPGDateType(t *testing.T) {
-	conn := fireboltConnection{clientMock, databaseMock, engineUrlMock, map[string]string{}}
+	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}}
 	loc, _ := time.LoadLocation("UTC")
 
 	// Value 0001-01-01 is outside of range of regular DATE
@@ -157,7 +157,7 @@ func TestConnectionQueryPGDateType(t *testing.T) {
 }
 
 func TestConnectionQueryTimestampNTZType(t *testing.T) {
-	conn := fireboltConnection{clientMock, databaseMock, engineUrlMock, map[string]string{}}
+	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}}
 	loc, _ := time.LoadLocation("UTC")
 
 	rows, err := conn.QueryContext(context.TODO(), "SELECT '0001-01-05 17:04:42.123456' :: TIMESTAMPNTZ;", nil)
@@ -176,7 +176,7 @@ func TestConnectionQueryTimestampNTZType(t *testing.T) {
 }
 
 func TestConnectionQueryTimestampTZType(t *testing.T) {
-	conn := fireboltConnection{clientMock, databaseMock, engineUrlMock, map[string]string{}}
+	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}}
 	loc, _ := time.LoadLocation("UTC")
 
 	rows, err := conn.QueryContext(context.TODO(), "SELECT '2023-01-05 17:04:42.1234 Europe/Berlin'::TIMESTAMPTZ;", nil)
@@ -198,7 +198,7 @@ func TestConnectionQueryTimestampTZType(t *testing.T) {
 }
 
 func TestConnectionQueryTimestampTZTypeAsia(t *testing.T) {
-	conn := fireboltConnection{clientMock, databaseMock, engineUrlMock, map[string]string{"time_zone": "Asia/Calcutta"}}
+	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"time_zone": "Asia/Calcutta", "database": databaseMock}}
 	loc, _ := time.LoadLocation("Asia/Calcutta")
 
 	rows, err := conn.QueryContext(context.TODO(), "SELECT '2023-01-05 17:04:42.123456 Europe/Berlin'::TIMESTAMPTZ;", nil)
@@ -220,7 +220,7 @@ func TestConnectionQueryTimestampTZTypeAsia(t *testing.T) {
 }
 
 func TestConnectionMultipleStatement(t *testing.T) {
-	conn := fireboltConnection{clientMock, databaseMock, engineUrlMock, map[string]string{}}
+	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}}
 	if rows, err := conn.QueryContext(context.TODO(), "SELECT -1; SELECT -2", nil); err != nil {
 		t.Errorf("Query multistement returned err: %v", err)
 	} else {
@@ -250,7 +250,7 @@ func TestConnectionMultipleStatement(t *testing.T) {
 }
 
 func TestConnectionQueryBooleanType(t *testing.T) {
-	conn := fireboltConnection{clientMock, databaseMock, engineUrlMock, map[string]string{}}
+	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}}
 
 	rows, err := conn.QueryContext(context.TODO(), "SELECT true, false, null::boolean;", nil)
 	if err != nil {
@@ -268,7 +268,7 @@ func TestConnectionQueryBooleanType(t *testing.T) {
 }
 
 func TestConnectionQueryByteaType(t *testing.T) {
-	conn := fireboltConnection{clientMock, databaseMock, engineUrlMock, map[string]string{}}
+	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}}
 
 	rows, err := conn.QueryContext(context.TODO(), "SELECT 'abc123'::bytea", nil)
 	if err != nil {
@@ -288,7 +288,7 @@ func TestConnectionQueryByteaType(t *testing.T) {
 }
 
 func TestConnectionPreparedStatement(t *testing.T) {
-	conn := fireboltConnection{clientMock, databaseMock, engineUrlMock, map[string]string{}}
+	conn := fireboltConnection{clientMock, engineUrlMock, map[string]string{"database": databaseMock}}
 
 	_, err := conn.QueryContext(
 		context.Background(),

--- a/connection_test.go
+++ b/connection_test.go
@@ -7,7 +7,7 @@ import (
 // TestConnectionPrepareStatement, tests that prepare statement doesn't result into an error
 func TestConnectionPrepareStatement(t *testing.T) {
 	emptyClient := ClientImplV0{}
-	fireboltConnection := fireboltConnection{&emptyClient, "database_name", "engine_url", map[string]string{}}
+	fireboltConnection := fireboltConnection{&emptyClient, "engine_url", map[string]string{}}
 
 	queryMock := "SELECT 1"
 	_, err := fireboltConnection.Prepare(queryMock)
@@ -20,7 +20,7 @@ func TestConnectionPrepareStatement(t *testing.T) {
 // and prepare statement on closed connection is not possible
 func TestConnectionClose(t *testing.T) {
 	emptyClient := ClientImplV0{}
-	fireboltConnection := fireboltConnection{&emptyClient, "database_name", "engine_url", map[string]string{}}
+	fireboltConnection := fireboltConnection{&emptyClient, "engine_url", map[string]string{}}
 	if err := fireboltConnection.Close(); err != nil {
 		t.Errorf("Close failed with an err: %v", err)
 	}

--- a/connection_test.go
+++ b/connection_test.go
@@ -7,7 +7,7 @@ import (
 // TestConnectionPrepareStatement, tests that prepare statement doesn't result into an error
 func TestConnectionPrepareStatement(t *testing.T) {
 	emptyClient := ClientImplV0{}
-	fireboltConnection := fireboltConnection{&emptyClient, "engine_url", map[string]string{}}
+	fireboltConnection := fireboltConnection{&emptyClient, "engine_url", map[string]string{}, nil}
 
 	queryMock := "SELECT 1"
 	_, err := fireboltConnection.Prepare(queryMock)
@@ -20,7 +20,7 @@ func TestConnectionPrepareStatement(t *testing.T) {
 // and prepare statement on closed connection is not possible
 func TestConnectionClose(t *testing.T) {
 	emptyClient := ClientImplV0{}
-	fireboltConnection := fireboltConnection{&emptyClient, "engine_url", map[string]string{}}
+	fireboltConnection := fireboltConnection{&emptyClient, "engine_url", map[string]string{}, nil}
 	if err := fireboltConnection.Close(); err != nil {
 		t.Errorf("Close failed with an err: %v", err)
 	}

--- a/driver.go
+++ b/driver.go
@@ -7,16 +7,23 @@ import (
 )
 
 type FireboltDriver struct {
-	engineUrl        string
-	databaseName     string
-	client           Client
-	lastUsedDsn      string
-	cachedParameters map[string]string
+	engineUrl    string
+	databaseName string
+	client       Client
+	lastUsedDsn  string
 }
 
 // Open parses the dsn string, and if correct tries to establish a connection
 func (d *FireboltDriver) Open(dsn string) (driver.Conn, error) {
-	infolog.Println("Opening firebolt driver")
+	conn, err := d.OpenConnector(dsn)
+	if err != nil {
+		return nil, err
+	}
+	return conn.Connect(context.Background())
+}
+
+func (d *FireboltDriver) OpenConnector(dsn string) (driver.Connector, error) {
+	infolog.Println("Opening firebolt connector")
 
 	if d.lastUsedDsn != dsn || d.lastUsedDsn == "" {
 
@@ -42,16 +49,34 @@ func (d *FireboltDriver) Open(dsn string) (driver.Conn, error) {
 		d.lastUsedDsn = dsn //nolint
 	}
 
-	parameters := map[string]string{"database": d.databaseName}
-	for k, v := range d.cachedParameters {
-		parameters[k] = v
-	}
-
-	infolog.Printf("firebolt connection is created")
-	return &fireboltConnection{d.client, d.engineUrl, parameters, d}, nil
+	return &FireboltConnector{d.engineUrl, d.databaseName, d.client, map[string]string{}, d}, nil
 }
 
-// init registers a firebolt driver
+// FireboltConnector is an intermediate type between a Connection and a Driver which stores session data
+type FireboltConnector struct {
+	engineUrl        string
+	databaseName     string
+	client           Client
+	cachedParameters map[string]string
+	driver           *FireboltDriver
+}
+
+// Connect returns a connection to the database
+func (c *FireboltConnector) Connect(ctx context.Context) (driver.Conn, error) {
+	parameters := map[string]string{"database": c.databaseName}
+	for k, v := range c.cachedParameters {
+		parameters[k] = v
+	}
+	infolog.Printf("firebolt connection is created")
+	return &fireboltConnection{c.client, c.engineUrl, parameters, c}, nil
+}
+
+// Driver returns the underlying driver of the Connector
+func (c *FireboltConnector) Driver() driver.Driver {
+	return c.driver
+}
+
+// init registers a firebolt connector
 func init() {
 	sql.Register("firebolt", &FireboltDriver{})
 }

--- a/driver.go
+++ b/driver.go
@@ -42,7 +42,7 @@ func (d FireboltDriver) Open(dsn string) (driver.Conn, error) {
 	}
 
 	infolog.Printf("firebolt connection is created")
-	return &fireboltConnection{d.client, d.databaseName, d.engineUrl, map[string]string{}}, nil
+	return &fireboltConnection{d.client, d.engineUrl, map[string]string{"database": d.databaseName}}, nil
 }
 
 // init registers a firebolt driver

--- a/driver.go
+++ b/driver.go
@@ -7,14 +7,15 @@ import (
 )
 
 type FireboltDriver struct {
-	engineUrl    string
-	databaseName string
-	client       Client
-	lastUsedDsn  string
+	engineUrl        string
+	databaseName     string
+	client           Client
+	lastUsedDsn      string
+	cachedParameters map[string]string
 }
 
 // Open parses the dsn string, and if correct tries to establish a connection
-func (d FireboltDriver) Open(dsn string) (driver.Conn, error) {
+func (d *FireboltDriver) Open(dsn string) (driver.Conn, error) {
 	infolog.Println("Opening firebolt driver")
 
 	if d.lastUsedDsn != dsn || d.lastUsedDsn == "" {
@@ -41,8 +42,13 @@ func (d FireboltDriver) Open(dsn string) (driver.Conn, error) {
 		d.lastUsedDsn = dsn //nolint
 	}
 
+	parameters := map[string]string{"database": d.databaseName}
+	for k, v := range d.cachedParameters {
+		parameters[k] = v
+	}
+
 	infolog.Printf("firebolt connection is created")
-	return &fireboltConnection{d.client, d.engineUrl, map[string]string{"database": d.databaseName}}, nil
+	return &fireboltConnection{d.client, d.engineUrl, parameters, d}, nil
 }
 
 // init registers a firebolt driver

--- a/driver_integration_test.go
+++ b/driver_integration_test.go
@@ -141,7 +141,7 @@ func TestDriverQueryResult(t *testing.T) {
 	}
 }
 
-// TestDriverOpenConnection checks making a connection on opened driver
+// TestDriverOpenConnection checks making a connection on opened connector
 func TestDriverOpenConnection(t *testing.T) {
 	db, err := sql.Open("firebolt", dsnMock)
 	if err != nil {
@@ -165,7 +165,7 @@ func runTestDriverExecStatement(t *testing.T, dsn string) {
 	}
 }
 
-// TestDriverOpenEngineUrl checks opening driver with a default engine
+// TestDriverOpenEngineUrl checks opening connector with a default engine
 func TestDriverOpenNoDatabase(t *testing.T) {
 	runTestDriverExecStatement(t, dsnNoDatabaseMock)
 }
@@ -204,7 +204,7 @@ func TestDriverSystemEngine(t *testing.T) {
 		fmt.Sprintf("CREATE DATABASE %s", databaseName),
 		fmt.Sprintf("CREATE ENGINE %s WITH SPEC = 'C1' SCALE = 1", engineName),
 		fmt.Sprintf("ATTACH ENGINE %s TO %s", engineName, databaseName),
-		fmt.Sprintf("ALTER DATABASE %s WITH DESCRIPTION = 'GO SDK Integration test'", databaseName),
+		fmt.Sprintf("ALTER DATABASE %s SET DESCRIPTION = 'GO SDK Integration test'", databaseName),
 		fmt.Sprintf("ALTER ENGINE %s RENAME TO %s", engineName, engineNewName),
 		fmt.Sprintf("START ENGINE %s", engineNewName),
 		fmt.Sprintf("STOP ENGINE %s", engineNewName),

--- a/driver_integration_v0_test.go
+++ b/driver_integration_v0_test.go
@@ -110,7 +110,7 @@ func TestDriverQueryResult(t *testing.T) {
 	}
 }
 
-// TestDriverOpenConnection checks making a connection on opened driver
+// TestDriverOpenConnection checks making a connection on opened connector
 func TestDriverOpenConnection(t *testing.T) {
 	db, err := sql.Open("firebolt", dsnMock)
 	if err != nil {
@@ -134,12 +134,12 @@ func runTestDriverExecStatement(t *testing.T, dsn string) {
 	}
 }
 
-// TestDriverOpenEngineUrl checks opening driver with a default engine
+// TestDriverOpenEngineUrl checks opening connector with a default engine
 func TestDriverOpenEngineUrl(t *testing.T) {
 	runTestDriverExecStatement(t, dsnEngineUrlMock)
 }
 
-// TestDriverOpenDefaultEngine checks opening driver with a default engine
+// TestDriverOpenDefaultEngine checks opening connector with a default engine
 func TestDriverOpenDefaultEngine(t *testing.T) {
 	runTestDriverExecStatement(t, dsnDefaultEngineMock)
 }
@@ -164,7 +164,7 @@ func TestDriverSystemEngine(t *testing.T) {
 		fmt.Sprintf("CREATE DATABASE %s", databaseName),
 		fmt.Sprintf("CREATE ENGINE %s WITH SPEC = 'C1' SCALE = 1", engineName),
 		fmt.Sprintf("ATTACH ENGINE %s TO %s", engineName, databaseName),
-		fmt.Sprintf("ALTER DATABASE %s WITH DESCRIPTION = 'GO SDK Integration test'", databaseName),
+		fmt.Sprintf("ALTER DATABASE %s SET DESCRIPTION = 'GO SDK Integration test'", databaseName),
 		fmt.Sprintf("ALTER ENGINE %s RENAME TO %s", engineName, engineNewName),
 		fmt.Sprintf("START ENGINE %s", engineNewName),
 		fmt.Sprintf("STOP ENGINE %s", engineNewName),

--- a/driver_test.go
+++ b/driver_test.go
@@ -1,28 +1,63 @@
 package fireboltgosdk
 
 import (
-	"context"
 	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"testing"
 )
 
-// TestDriverOpen tests that the driver is opened (happy path)
+// TestDriverOpen tests that the connector is opened (happy path)
 func TestDriverOpen(t *testing.T) {
-	db, err := sql.Open("firebolt", "firebolt://user:pass@db_name")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == UsernamePasswordURLSuffix {
+			_, _ = w.Write(getAuthResponse(10000))
+		} else if r.URL.Path == DefaultAccountURL {
+			_, _ = w.Write(getDefaultAccountResponse())
+		}
+	}))
+	defer server.Close()
+
+	currentEndpoint := os.Getenv("FIREBOLT_ENDPOINT")
+	os.Setenv("FIREBOLT_ENDPOINT", server.URL)
+	defer os.Setenv("FIREBOLT_ENDPOINT", currentEndpoint)
+
+	db, err := sql.Open("firebolt", "firebolt://user@fb:pass@db_name/eng.firebolt.io")
 	if err != nil {
-		t.Errorf("failed unexpectedly")
+		t.Errorf("connection failed unexpectedly: %v", err)
 	}
 	if _, ok := db.Driver().(*FireboltDriver); !ok {
-		t.Errorf("returned driver is not a firebolt driver")
+		t.Errorf("returned connector is not a firebolt connector")
 	}
 }
 
-// TestDriverOpenFail tests opening a driver with wrong dsn
-func TestDriverOpenFail(t *testing.T) {
-	db, _ := sql.Open("firebolt", "firebolt://pass@db_name")
-	ctx := context.TODO()
+func getDefaultAccountResponse() []byte {
+	var response = `{
+       "account": {
+           "name": "default_account",
+           "id": "default_account_id"
+       }
+    }`
+	return []byte(response)
+}
 
-	if _, err := db.Conn(ctx); err == nil {
+// TestDriverOpenFail tests opening a connector with wrong dsn
+func TestDriverOpenFail(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == UsernamePasswordURLSuffix {
+			_, _ = w.Write(getAuthResponse(10000))
+		} else if r.URL.Path == DefaultAccountURL {
+			_, _ = w.Write(getDefaultAccountResponse())
+		}
+	}))
+	defer server.Close()
+
+	currentEndpoint := os.Getenv("FIREBOLT_ENDPOINT")
+	os.Setenv("FIREBOLT_ENDPOINT", server.URL)
+	defer os.Setenv("FIREBOLT_ENDPOINT", currentEndpoint)
+
+	if _, err := sql.Open("firebolt", "firebolt://pass@db_name"); err == nil {
 		t.Errorf("missing username in dsn should result into sql.Open error")
 	}
 }

--- a/performance_test.go
+++ b/performance_test.go
@@ -1,3 +1,6 @@
+//go:build performance
+// +build performance
+
 package fireboltgosdk
 
 import (
@@ -25,7 +28,7 @@ func TestMain(m *testing.M) {
 	pool, err = sql.Open("firebolt", dsn)
 
 	if err != nil {
-		log.Fatal("error during opening a driver", err)
+		log.Fatal("error during opening a connector", err)
 	}
 	code := m.Run()
 	err = pool.Close()


### PR DESCRIPTION
This PR aims to add support for USE DATABASE statement for go sdk. However, this change also led to a couple of improvements that needed to be done:
- Add driver-level caching of set parameters and database parameter. This was needed since parameters currently can potentially be lost between each query execution. This is due to `database/sql` underlying behavior. We didn't notice this before because we didn't use `sql.Open` in integration tests.
- Updated integration tests to use `sql.Open` in most cases. This leads to a propper functionality check since it's the way users interact with the driver 