### PR TITLE
feat: FIR-29878: extend driver with custom connector builder

### DIFF
--- a/driver_options.go
+++ b/driver_options.go
@@ -1,0 +1,53 @@
+package fireboltgosdk
+
+type driverOption func(d *FireboltDriver)
+
+// WithEngineUrl defines engine url for the driver
+func WithEngineUrl(engineUrl string) driverOption {
+	return func(d *FireboltDriver) {
+		d.engineUrl = engineUrl
+	}
+}
+
+// WithDatabaseName defines database name for the driver
+func WithDatabaseName(databaseName string) driverOption {
+	return func(d *FireboltDriver) {
+		d.databaseName = databaseName
+	}
+}
+
+// WithClientParams defines client parameters for the driver
+func WithClientParams(accountID string, token string, userAgent string) driverOption {
+	return func(d *FireboltDriver) {
+		cl := &ClientImpl{
+			ConnectedToSystemEngine: true,
+		}
+
+		cl.AccountID = accountID
+		cl.UserAgent = userAgent
+
+		cl.parameterGetter = cl.getQueryParams
+		cl.accessTokenGetter = func() (string, error) {
+			return token, nil
+		}
+
+		d.client = cl
+	}
+}
+
+// FireboltConnectorWithOptions builds a custom connector
+func FireboltConnectorWithOptions(opts ...driverOption) *FireboltConnector {
+	d := &FireboltDriver{}
+
+	for _, opt := range opts {
+		opt(d)
+	}
+
+	return &FireboltConnector{
+		d.engineUrl,
+		d.databaseName,
+		d.client,
+		map[string]string{},
+		d,
+	}
+}

--- a/driver_options_test.go
+++ b/driver_options_test.go
@@ -1,0 +1,35 @@
+package fireboltgosdk
+
+import (
+	"testing"
+)
+
+func TestDriverOptions(t *testing.T) {
+	engineUrl := "https://engine.url"
+	databaseName := "database_name"
+	accountID := "account-id"
+	token := "1234567890"
+	userAgent := "UA Test"
+
+	conn := FireboltConnectorWithOptions(
+		WithEngineUrl(engineUrl),
+		WithDatabaseName(databaseName),
+		WithClientParams(accountID, token, userAgent),
+	)
+
+	assert(conn.engineUrl, engineUrl, t, "engineUrl is invalid")
+	assert(conn.databaseName, databaseName, t, "databaseName is invalid")
+
+	cl, ok := conn.client.(*ClientImpl)
+	assert(ok, true, t, "client is not *ClientImpl")
+
+	assert(cl.AccountID, accountID, t, "accountID is invalid")
+	assert(cl.UserAgent, userAgent, t, "userAgent is invalid")
+
+	tok, err := cl.accessTokenGetter()
+	if err != nil {
+		t.Errorf("token getter returned an error: %v", err)
+	}
+
+	assert(tok, token, t, "token getter returned wrong token")
+}


### PR DESCRIPTION
This change allows to build a custom `FireboltConnector` with its parameters overriden