### PR TITLE
feat: Parameter deny list

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -88,6 +88,10 @@ func processSetStatement(ctx context.Context, c *fireboltConnection, query strin
 		// if parsing of set statement returned an error, we will not handle the request as a set statement
 		return false, nil
 	}
+	err = validateSetStatement(setKey)
+	if err != nil {
+		return false, err
+	}
 
 	parameters := map[string]string{setKey: setValue}
 	if db, ok := c.parameters["database"]; ok {

--- a/connection_test.go
+++ b/connection_test.go
@@ -1,6 +1,8 @@
 package fireboltgosdk
 
 import (
+	"context"
+	"strings"
 	"testing"
 )
 
@@ -29,4 +31,24 @@ func TestConnectionClose(t *testing.T) {
 	if err == nil {
 		t.Errorf("Prepare on closed connection didn't fail, but it should")
 	}
+}
+
+func runProcessSetStatementFail(t *testing.T, value string) {
+	emptyClient := ClientImpl{} // Client version is irrelevant for this test
+	fireboltConnection := fireboltConnection{&emptyClient, "engine_url", map[string]string{}, nil}
+	expectedError := "could not set parameter"
+
+	_, err := processSetStatement(context.TODO(), &fireboltConnection, value)
+	if err == nil {
+		t.Errorf("processSetStatement didn't fail, but it should")
+	} else if !strings.Contains(err.Error(), expectedError) {
+		t.Errorf("processSetStatement failed with unexpected error, expected error to contain: %v got: %v", expectedError, err)
+	}
+}
+
+func TestProcessSetStatement(t *testing.T) {
+	runProcessSetStatementFail(t, "SET database=my_db")
+	runProcessSetStatementFail(t, "SET engine=my_engine")
+	runProcessSetStatementFail(t, "SET account_id=1")
+	runProcessSetStatementFail(t, "SET output_format='json'")
 }

--- a/utils.go
+++ b/utils.go
@@ -22,6 +22,29 @@ func ConstructNestedError(message string, err error) error {
 	return fmt.Errorf("%s: %v", message, err)
 }
 
+func validateSetStatement(key string) error {
+	useParameterList := []string{"database", "engine"}
+	disallowedParameterList := []string{"account_id", "output_format"}
+
+	for _, denyKey := range useParameterList {
+		if key == denyKey {
+			return fmt.Errorf("could not set parameter. "+
+				"Set parameter '%s' is not allowed. "+
+				"Try again with 'USE %s' instead of SET", key, strings.ToUpper(key))
+		}
+	}
+
+	for _, denyKey := range disallowedParameterList {
+		if key == denyKey {
+			return fmt.Errorf("could not set parameter. "+
+				"Set parameter '%s' is not allowed. "+
+				"Try again with a different parameter name", key)
+		}
+	}
+
+	return nil
+}
+
 // parseSetStatement parses a single set statement and returns a key-value pair,
 // or returns an error, if it isn't a set statement
 func parseSetStatement(query string) (string, string, error) {


### PR DESCRIPTION
FIR-30143
Some set parameters are not allowed. Adding an appropriate error message for them.

Only unit tests as integration tests are not applicable here since this is a client side check.