### PR TITLE
fix: bytea formatting for new ff

### DIFF
--- a/client_integration_v0_test.go
+++ b/client_integration_v0_test.go
@@ -119,7 +119,7 @@ func TestQuerySetStatements(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error parsing date: %v", err)
 	}
-	if date.(time.Time).Hour() != 5 {
+	if date.(time.Time).UTC().Hour() != 5 {
 		t.Errorf("Invalid date returned: %s", date)
 	}
 }

--- a/connection_common_integration_test.go
+++ b/connection_common_integration_test.go
@@ -482,8 +482,8 @@ func TestLongQuery(t *testing.T) {
 	}()
 	select {
 	case elapsed := <-finished_in:
-		if elapsed > 350*time.Minute {
-			t.Errorf("Expected execution time to be more than 350 sec but was %v sec", elapsed)
+		if elapsed < 350*time.Second {
+			t.Errorf("Expected execution time to be more than 350 sec but was %v", elapsed)
 		}
 	case <-time.After(10 * time.Minute):
 		t.Errorf("Long query didn't finish in 10 minutes")

--- a/connection_common_integration_test.go
+++ b/connection_common_integration_test.go
@@ -460,12 +460,7 @@ func TestConnectionPreparedStatement(t *testing.T) {
 }
 
 func TestLongQuery(t *testing.T) {
-	var maxValue = 0
-	if v0Testing {
-		maxValue = 250000000000
-	} else {
-		maxValue = 430000000000
-	}
+	var maxValue = 430000000000
 
 	finished_in := make(chan time.Duration, 1)
 	go func() {

--- a/connection_common_integration_test.go
+++ b/connection_common_integration_test.go
@@ -478,7 +478,7 @@ func TestLongQuery(t *testing.T) {
 	select {
 	case elapsed := <-finished_in:
 		if elapsed < 350*time.Second {
-			t.Errorf("Expected execution time to be more than 350 sec but was %v sec", elapsed.(int64))
+			t.Errorf("Expected execution time to be more than 350 sec but was %v sec", elapsed)
 		}
 	case <-time.After(10 * time.Minute):
 		t.Errorf("Long query didn't finish in 10 minutes")

--- a/connection_common_integration_test.go
+++ b/connection_common_integration_test.go
@@ -483,7 +483,7 @@ func TestLongQuery(t *testing.T) {
 	select {
 	case elapsed := <-finished_in:
 		if elapsed < 350*time.Second {
-			t.Errorf("Expected execution time to be more than 350 sec but was %v", elapsed)
+			t.Errorf("Expected execution time to be more than 350 sec but was %v sec", elapsed.(int64))
 		}
 	case <-time.After(10 * time.Minute):
 		t.Errorf("Long query didn't finish in 10 minutes")

--- a/connection_common_integration_test.go
+++ b/connection_common_integration_test.go
@@ -394,7 +394,7 @@ func TestConnectionPreparedStatement(t *testing.T) {
 	d := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
 	ts := time.Date(2021, 1, 1, 2, 10, 20, 3000, time.UTC)
 	tstz := time.Date(2021, 1, 1, 2, 10, 20, 3000, loc)
-	ba := []byte("hello_world_123ツ\n\\u0048")
+	ba := []byte("hello_world_123ツ\n\u0048")
 
 	_, err = conn.QueryContext(
 		context.Background(),

--- a/utils.go
+++ b/utils.go
@@ -2,7 +2,6 @@ package fireboltgosdk
 
 import (
 	"database/sql/driver"
-	"encoding/hex"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -158,7 +157,11 @@ func formatValue(value driver.Value) (string, error) {
 		return fmt.Sprintf("'%s'", timeValue.Format(layout)), nil
 	case []byte:
 		byteValue := value.([]byte)
-		return fmt.Sprintf("'\\x%s'", hex.EncodeToString(byteValue)), nil
+		parts := make([]string, len(byteValue))
+		for i, b := range byteValue {
+			parts[i] = fmt.Sprintf("\\x%02x", b)
+		}
+		return fmt.Sprintf("E'%s'", strings.Join(parts, "")), nil
 	case nil:
 		return "NULL", nil
 	default:

--- a/utils_test.go
+++ b/utils_test.go
@@ -116,7 +116,7 @@ func TestFormatValue(t *testing.T) {
 	runTestFormatValue(t, false, "false")
 	runTestFormatValue(t, -10, "-10")
 	runTestFormatValue(t, nil, "NULL")
-	runTestFormatValue(t, []byte("abcd"), "'\\x61626364'")
+	runTestFormatValue(t, []byte("abcd"), "E'\\x61\\x62\\x63\\x64'")
 	// Time
 	runTestFormatValue(t, time.Date(2022, 01, 10, 1, 3, 2, 123000, time.UTC), "'2022-01-10 01:03:02.000123'")
 	runTestFormatValue(t, time.Date(2022, 01, 10, 1, 3, 2, 123000, time.FixedZone("", 0)), "'2022-01-10 01:03:02.000123'")


### PR DESCRIPTION
- Implement a universal bytea formatting for both `standard_conforming_strings` enabled and disabled
- Added fixes for long query test