### PR TITLE
fix: ignore empty parts in multistatement queries

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -120,6 +120,9 @@ func SplitStatements(sql string) ([]string, error) {
 		if err != nil {
 			return nil, ConstructNestedError("error during splitting query", err)
 		}
+		if strings.Trim(query, " \t\n") == "" {
+			continue
+		}
 		queries = append(queries, query)
 	}
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -180,8 +180,9 @@ func runSplitStatement(t *testing.T, value string, expected []string) {
 func TestSplitStatements(t *testing.T) {
 	runSplitStatement(t, "SELECT 1; SELECT 2;", []string{"SELECT 1", " SELECT 2"})
 	runSplitStatement(t, "SELECT 1;", []string{"SELECT 1"})
+	runSplitStatement(t, "SELECT 1; ", []string{"SELECT 1"})
 	runSplitStatement(t, "SELECT 1", []string{"SELECT 1"})
-	runSplitStatement(t, "SELECT 1; ; ; ; ", []string{"SELECT 1", " ", " ", " ", " "})
+	runSplitStatement(t, "SELECT 1; ; ; ; ", []string{"SELECT 1"})
 
 	runSplitStatement(t, "SET time_zone=America/New_York; SELECT 2 /*some ; comment*/", []string{"SET time_zone=America/New_York", " SELECT 2 /*some ; comment*/"})
 	runSplitStatement(t, "SET time_zone='America/New_York'; SELECT 2 /*some ; comment*/", []string{"SET time_zone='America/New_York'", " SELECT 2 /*some ; comment*/"})


### PR DESCRIPTION
As the title says. There is no need to execute queries only have spaces, tabs or lineends in them