### PR TITLE
ci: pin macos runners to 13

### DIFF
--- a/.github/workflows/nightly-v1.yml
+++ b/.github/workflows/nightly-v1.yml
@@ -11,26 +11,26 @@ jobs:
     strategy:
       fail-fast: false # finish all jobs even if one fails
       max-parallel: 2
-      matrix: 
-        os: ['macos-latest', 'windows-latest', 'ubuntu-latest']
+      matrix:
+        os: ['macos-13', 'windows-latest', 'ubuntu-latest']
         go-version: ['1.16', '1.17', '1.18', '1.19']
     steps:
       - name: Check out code
         uses: actions/checkout@v2
-      
+
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
-   
+
       - name: Install go tools
         run: go get golang.org/x/tools/cmd/cover
- 
+
       - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
           python-version: "3.7"
-    
+
       - name: Setup database and engine
         id: setup
         uses: firebolt-db/integration-testing-setup@v1
@@ -66,7 +66,7 @@ jobs:
           colour=$(if [ $percentage_whole -ge 80 ]; then echo "green"; else echo "orange"; fi)
           echo "colour=$colour" >>  $GITHUB_OUTPUT
           echo "covered=$percentage_whole" >>  $GITHUB_OUTPUT
-    
+
       - name: Create Coverage Badge
         uses: schneegans/dynamic-badges-action@v1.2.0
         continue-on-error: true
@@ -77,7 +77,7 @@ jobs:
           label: Coverage
           message: ${{steps.coverage.outputs.covered}}%
           color: ${{steps.coverage.outputs.colour}}
-  
+
       - name: Slack Notify of failure
         if: failure()
         id: slack

--- a/.github/workflows/nightly-v2.yml
+++ b/.github/workflows/nightly-v2.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false # finish all jobs even if one fails
       max-parallel: 2
       matrix:
-        os: ['macos-latest', 'windows-latest', 'ubuntu-latest']
+        os: ['macos-13', 'windows-latest', 'ubuntu-latest']
         go-version: ['1.16', '1.17', '1.18', '1.19']
     steps:
       - name: Check out code


### PR DESCRIPTION
There's currently a bug with macos-latest and certain versions of Python so we need to pin macos runners to the one behind latest.