### PR TITLE
test: Align slow test param with other sdks

### DIFF
--- a/connection_common_integration_test.go
+++ b/connection_common_integration_test.go
@@ -460,7 +460,7 @@ func TestConnectionPreparedStatement(t *testing.T) {
 }
 
 func TestLongQuery(t *testing.T) {
-	var maxValue = 430000000000
+	var maxValue = 400000000000
 
 	finished_in := make(chan time.Duration, 1)
 	go func() {


### PR DESCRIPTION
Fixing this constant to be in line with Python SDK, where a similar test seems to work well without failures.