### PR TITLE
ci: Reschedule nightly runs to 2am UTC

### DIFF
--- a/.github/workflows/nightly-v1.yml
+++ b/.github/workflows/nightly-v1.yml
@@ -2,7 +2,7 @@ name: Nightly code check
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 7 * * *' # 2 am UTC every day
+    - cron: '0 2 * * *' # 2 am UTC every day
 jobs:
   code-check:
     uses: ./.github/workflows/code-check.yml

--- a/.github/workflows/nightly-v1.yml
+++ b/.github/workflows/nightly-v1.yml
@@ -2,7 +2,7 @@ name: Nightly code check
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 10 * * *' # 5 am UTC every day
+    - cron: '0 7 * * *' # 2 am UTC every day
 jobs:
   code-check:
     uses: ./.github/workflows/code-check.yml

--- a/.github/workflows/nightly-v2.yml
+++ b/.github/workflows/nightly-v2.yml
@@ -2,7 +2,7 @@ name: Nightly code check V2
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 10 * * *' # 5 am UTC every day
+    - cron: '0 7 * * *' # 2 am UTC every day
 jobs:
   code-check:
     uses: ./.github/workflows/code-check.yml

--- a/.github/workflows/nightly-v2.yml
+++ b/.github/workflows/nightly-v2.yml
@@ -2,7 +2,7 @@ name: Nightly code check V2
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 7 * * *' # 2 am UTC every day
+    - cron: '0 2 * * *' # 2 am UTC every day
 jobs:
   code-check:
     uses: ./.github/workflows/code-check.yml


### PR DESCRIPTION
Since only this repo nightlies are failing sporadically I'm trying to test if the timing of the run is affecting it.
Other nightlies currently run 3am onwards so setting this one to 2am.