### PR TITLE
fix: Fir 33266 use quoted identifiers in go sdk

### DIFF
--- a/client.go
+++ b/client.go
@@ -191,12 +191,14 @@ func (c *ClientImpl) getConnectionParametersV2(
 		resetParameters: func() {},
 	}
 	if databaseName != "" {
-		if _, err := c.Query(ctx, engineURL, "USE DATABASE "+databaseName, parameters, control); err != nil {
+		sql := fmt.Sprintf("USE DATABASE \"%s\"", databaseName)
+		if _, err := c.Query(ctx, engineURL, sql, parameters, control); err != nil {
 			return "", nil, err
 		}
 	}
 	if engineName != "" {
-		if _, err := c.Query(ctx, engineURL, "USE ENGINE "+engineName, parameters, control); err != nil {
+		sql := fmt.Sprintf("USE ENGINE \"%s\"", engineName)
+		if _, err := c.Query(ctx, engineURL, sql, parameters, control); err != nil {
 			return "", nil, err
 		}
 	}

--- a/connection_integration_test.go
+++ b/connection_integration_test.go
@@ -6,6 +6,7 @@ package fireboltgosdk
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"testing"
 )
 
@@ -15,11 +16,11 @@ func setupEngineAndDatabase(t *testing.T) {
 		t.Errorf("opening a connection failed unexpectedly: %v", err)
 		t.FailNow()
 	}
-	if _, err = conn.Exec("CREATE DATABASE IF NOT EXISTS " + databaseMock); err != nil {
+	if _, err = conn.Exec(fmt.Sprintf("CREATE DATABASE IF NOT EXISTS \"%s\"", databaseMock)); err != nil {
 		t.Errorf("creating a database failed unexpectedly: %v", err)
 		t.FailNow()
 	}
-	if _, err = conn.Exec("CREATE ENGINE IF NOT EXISTS " + engineNameMock); err != nil {
+	if _, err = conn.Exec(fmt.Sprintf("CREATE ENGINE IF NOT EXISTS \"%s\"", engineNameMock)); err != nil {
 		t.Errorf("creating an engine failed unexpectedly: %v", err)
 		t.FailNow()
 	}
@@ -31,15 +32,15 @@ func cleanupEngineAndDatabase(t *testing.T) {
 		t.Errorf("opening a connection failed unexpectedly: %v", err)
 		t.FailNow()
 	}
-	if _, err = conn.Exec("STOP ENGINE " + engineNameMock); err != nil {
+	if _, err = conn.Exec(fmt.Sprintf("STOP ENGINE \"%s\"", engineNamemock)); err != nil {
 		t.Errorf("stopping an engine failed unexpectedly: %v", err)
 		t.FailNow()
 	}
-	if _, err = conn.Exec("DROP ENGINE IF EXISTS " + engineNameMock); err != nil {
+	if _, err = conn.Exec(fmt.Sprintf("DROP ENGINE IF EXISTS \"%s\"", engineNameMock)); err != nil {
 		t.Errorf("dropping an engine failed unexpectedly: %v", err)
 		t.FailNow()
 	}
-	if _, err = conn.Exec("DROP DATABASE IF EXISTS " + databaseMock); err != nil {
+	if _, err = conn.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS \"%s\"", databaseMock)); err != nil {
 		t.Errorf("dropping a database failed unexpectedly: %v", err)
 		t.FailNow()
 	}
@@ -147,7 +148,7 @@ func TestConnectionV2UseDatabaseEngine(t *testing.T) {
 		t.FailNow()
 	}
 
-	_, err = conn.Exec("USE DATABASE " + databaseMock)
+	_, err = conn.Exec(fmt.Sprintf("USE DATABASE \"%s\"", databaseMock))
 	if err != nil {
 		t.Errorf("use database failed with %v", err)
 		t.FailNow()
@@ -165,7 +166,7 @@ func TestConnectionV2UseDatabaseEngine(t *testing.T) {
 		t.FailNow()
 	}
 
-	_, err = conn.Exec("USE ENGINE " + engineNameMock)
+	_, err = conn.Exec(fmt.Sprintf("USE ENGINE \"%s\"", engineNameMock))
 	if err != nil {
 		t.Errorf("use engine failed with %v", err)
 		t.FailNow()

--- a/driver_integration_test.go
+++ b/driver_integration_test.go
@@ -244,7 +244,7 @@ func TestDriverSystemEngine(t *testing.T) {
 		fmt.Sprintf("CREATE DATABASE \"%s\"", databaseName),
 		fmt.Sprintf("CREATE ENGINE \"%s\" WITH SPEC = 'C1' SCALE = 1", engineName),
 		fmt.Sprintf("ATTACH ENGINE \"%s\" TO \"%s\"", engineName, databaseName),
-		fmt.Sprintf("ALTER DATABASE \"%s\\\" SET DESCRIPTION = 'GO SDK Integration test'", databaseName),
+		fmt.Sprintf("ALTER DATABASE \"%s\" SET DESCRIPTION = 'GO SDK Integration test'", databaseName),
 		fmt.Sprintf("ALTER ENGINE \"%s\" RENAME TO %s", engineName, engineNewName),
 		fmt.Sprintf("START ENGINE \"%s\"", engineNewName),
 		fmt.Sprintf("STOP ENGINE \"%s\"", engineNewName),

--- a/driver_integration_test.go
+++ b/driver_integration_test.go
@@ -241,25 +241,25 @@ func TestDriverSystemEngine(t *testing.T) {
 		t.Errorf("failed unexpectedly with %v", err)
 	}
 	ddlStatements := []string{
-		fmt.Sprintf("CREATE DATABASE %s", databaseName),
-		fmt.Sprintf("CREATE ENGINE %s WITH SPEC = 'C1' SCALE = 1", engineName),
-		fmt.Sprintf("ATTACH ENGINE %s TO %s", engineName, databaseName),
-		fmt.Sprintf("ALTER DATABASE %s SET DESCRIPTION = 'GO SDK Integration test'", databaseName),
-		fmt.Sprintf("ALTER ENGINE %s RENAME TO %s", engineName, engineNewName),
-		fmt.Sprintf("START ENGINE %s", engineNewName),
-		fmt.Sprintf("STOP ENGINE %s", engineNewName),
+		fmt.Sprintf("CREATE DATABASE \"%s\"", databaseName),
+		fmt.Sprintf("CREATE ENGINE \"%s\" WITH SPEC = 'C1' SCALE = 1", engineName),
+		fmt.Sprintf("ATTACH ENGINE \"%s\" TO \"%s\"", engineName, databaseName),
+		fmt.Sprintf("ALTER DATABASE \"%s\\\" SET DESCRIPTION = 'GO SDK Integration test'", databaseName),
+		fmt.Sprintf("ALTER ENGINE \"%s\" RENAME TO %s", engineName, engineNewName),
+		fmt.Sprintf("START ENGINE \"%s\"", engineNewName),
+		fmt.Sprintf("STOP ENGINE \"%s\"", engineNewName),
 	}
 
 	// Cleanup
 	defer func() {
-		stopEngineQuery := fmt.Sprintf("STOP ENGINE %s", engineName)
-		stopNewEngineQuery := fmt.Sprintf("STOP ENGINE %s", engineNewName)
-		dropEngineQuery := fmt.Sprintf("DROP ENGINE IF EXISTS %s", engineName)
-		dropNewEngineQuery := fmt.Sprintf("DROP ENGINE IF EXISTS %s", engineNewName)
+		stopEngineQuery := fmt.Sprintf("STOP ENGINE \"%s\"", engineName)
+		stopNewEngineQuery := fmt.Sprintf("STOP ENGINE \"%s\"", engineNewName)
+		dropEngineQuery := fmt.Sprintf("DROP ENGINE IF EXISTS \"%s\"", engineName)
+		dropNewEngineQuery := fmt.Sprintf("DROP ENGINE IF EXISTS \"%s\"", engineNewName)
 		for _, query := range []string{stopEngineQuery, stopNewEngineQuery, dropEngineQuery, dropNewEngineQuery} {
 			db.Query(query)
 		}
-		dropDbQuery := fmt.Sprintf("DROP DATABASE %s", databaseName)
+		dropDbQuery := fmt.Sprintf("DROP DATABASE \"%s\"", databaseName)
 		_, err = db.Query(dropDbQuery)
 		if err != nil {
 			t.Errorf("The cleanup query %s returned an error: %v", dropDbQuery, err)

--- a/driver_integration_v0_test.go
+++ b/driver_integration_v0_test.go
@@ -193,25 +193,25 @@ func TestDriverSystemEngine(t *testing.T) {
 		t.Errorf("failed unexpectedly with %v", err)
 	}
 	ddlStatements := []string{
-		fmt.Sprintf("CREATE DATABASE %s", databaseName),
-		fmt.Sprintf("CREATE ENGINE %s WITH SPEC = 'C1' SCALE = 1", engineName),
-		fmt.Sprintf("ATTACH ENGINE %s TO %s", engineName, databaseName),
-		fmt.Sprintf("ALTER DATABASE %s SET DESCRIPTION = 'GO SDK Integration test'", databaseName),
-		fmt.Sprintf("ALTER ENGINE %s RENAME TO %s", engineName, engineNewName),
-		fmt.Sprintf("START ENGINE %s", engineNewName),
-		fmt.Sprintf("STOP ENGINE %s", engineNewName),
+		fmt.Sprintf("CREATE DATABASE \"%s\"", databaseName),
+		fmt.Sprintf("CREATE ENGINE \"%s\" WITH SPEC = 'C1' SCALE = 1", engineName),
+		fmt.Sprintf("ATTACH ENGINE \"%s\" TO \"%s\"", engineName, databaseName),
+		fmt.Sprintf("ALTER DATABASE \"%s\" SET DESCRIPTION = 'GO SDK Integration test'", databaseName),
+		fmt.Sprintf("ALTER ENGINE \"%s\" RENAME TO \"%s\"", engineName, engineNewName),
+		fmt.Sprintf("START ENGINE \"%s\"", engineNewName),
+		fmt.Sprintf("STOP ENGINE \"%s\"", engineNewName),
 	}
 
 	// Cleanup
 	defer func() {
-		stopEngineQuery := fmt.Sprintf("STOP ENGINE %s", engineName)
-		stopNewEngineQuery := fmt.Sprintf("STOP ENGINE %s", engineNewName)
-		dropEngineQuery := fmt.Sprintf("DROP ENGINE IF EXISTS %s", engineName)
-		dropNewEngineQuery := fmt.Sprintf("DROP ENGINE IF EXISTS %s", engineNewName)
+		stopEngineQuery := fmt.Sprintf("STOP ENGINE \"%s\"", engineName)
+		stopNewEngineQuery := fmt.Sprintf("STOP ENGINE \"%s\"", engineNewName)
+		dropEngineQuery := fmt.Sprintf("DROP ENGINE IF EXISTS \"%s\"", engineName)
+		dropNewEngineQuery := fmt.Sprintf("DROP ENGINE IF EXISTS \"%s\"", engineNewName)
 		for _, query := range []string{stopEngineQuery, stopNewEngineQuery, dropEngineQuery, dropNewEngineQuery} {
 			db.Query(query)
 		}
-		dropDbQuery := fmt.Sprintf("DROP DATABASE %s", databaseName)
+		dropDbQuery := fmt.Sprintf("DROP DATABASE \"%s\"", databaseName)
 		_, err = db.Query(dropDbQuery)
 		if err != nil {
 			t.Errorf("The cleanup query %s returned an error: %v", dropDbQuery, err)


### PR DESCRIPTION
Added quoted identifiers where needed
- USE ENGINE/USE DATABASE commands during connection
- Tests setup/cleanup