### PR TITLE
fix: Combining set statements

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -98,7 +98,10 @@ func processSetStatement(ctx context.Context, c *fireboltConnection, query strin
 	}
 
 	// combine parameters from connection and set statement
-	combinedParameters := c.parameters
+	combinedParameters := make(map[string]string)
+	for k, v := range c.parameters {
+		combinedParameters[k] = v
+	}
 	combinedParameters[setKey] = setValue
 
 	_, err = c.client.Query(ctx, c.engineUrl, "SELECT 1", combinedParameters, connectionControl{

--- a/connection.go
+++ b/connection.go
@@ -97,11 +97,11 @@ func processSetStatement(ctx context.Context, c *fireboltConnection, query strin
 		return false, err
 	}
 
-	parameters := map[string]string{setKey: setValue}
-	if db, ok := c.parameters["database"]; ok {
-		parameters["database"] = db
-	}
-	_, err = c.client.Query(ctx, c.engineUrl, "SELECT 1", parameters, connectionControl{
+	// combine parameters from connection and set statement
+	combinedParameters := c.parameters
+	combinedParameters[setKey] = setValue
+
+	_, err = c.client.Query(ctx, c.engineUrl, "SELECT 1", combinedParameters, connectionControl{
 		updateParameters: c.setParameter,
 		setEngineURL:     c.setEngineURL,
 		resetParameters:  c.resetParameters,

--- a/connection_test.go
+++ b/connection_test.go
@@ -87,9 +87,12 @@ func TestMultipleSetParameters(t *testing.T) {
 	emptyClient := MockClient{}
 
 	fireboltConnection := fireboltConnection{&emptyClient, "engine_url", map[string]string{}, &connector}
+	var err error
 
-	processSetStatement(context.TODO(), &fireboltConnection, "SET key1=value1")
-	processSetStatement(context.TODO(), &fireboltConnection, "SET key2=value")
+	_, err = processSetStatement(context.TODO(), &fireboltConnection, "SET key1=value1")
+	raiseIfError(t, err)
+	_, err = processSetStatement(context.TODO(), &fireboltConnection, "SET key2=value")
+	raiseIfError(t, err)
 	// Check if parameters were set correctly
 	if len(emptyClient.ParametersCalled) != 2 {
 		t.Errorf("processSetStatement didn't set parameters correctly")

--- a/connection_test.go
+++ b/connection_test.go
@@ -2,6 +2,7 @@ package fireboltgosdk
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 )
@@ -105,6 +106,54 @@ func TestMultipleSetParameters(t *testing.T) {
 	}
 	if _, ok := emptyClient.ParametersCalled[1]["key1"]; !ok {
 		t.Errorf("processSetStatement didn't use previous parameters correctly")
+	}
+}
+
+// MockClient rudimentary mocks Client and tracks the parameters passed to Query
+type MockClientFailingQuery struct {
+	ParametersCalled []map[string]string
+}
+
+func (m *MockClientFailingQuery) Query(ctx context.Context, engineUrl, query string, parameters map[string]string, control connectionControl) (*QueryResponse, error) {
+	m.ParametersCalled = append(m.ParametersCalled, parameters)
+	return nil, errors.New("dummy error")
+}
+
+func (m *MockClientFailingQuery) GetConnectionParameters(ctx context.Context, engineName string, databaseName string) (string, map[string]string, error) {
+	// Implement to satisfy Client interface
+	return "", nil, nil
+}
+
+func TestFailingQueryDoesntSetParameter(t *testing.T) {
+	connector := FireboltConnector{}
+	emptyClient := MockClientFailingQuery{}
+
+	fireboltConnection := fireboltConnection{&emptyClient, "engine_url", map[string]string{}, &connector}
+	var err error
+
+	_, err = processSetStatement(context.TODO(), &fireboltConnection, "SET key1=value1")
+	if err == nil {
+		t.Errorf("processSetStatement didn't fail, but it should")
+	}
+	_, err = processSetStatement(context.TODO(), &fireboltConnection, "SET key2=value")
+	if err == nil {
+		t.Errorf("processSetStatement didn't fail, but it should")
+	}
+	// Check if parameters were set correctly
+	if len(emptyClient.ParametersCalled) != 2 {
+		t.Errorf("processSetStatement didn't set parameters correctly")
+	}
+	if _, ok := emptyClient.ParametersCalled[0]["key1"]; !ok {
+		t.Errorf("processSetStatement didn't set parameter correctly")
+	}
+	if _, ok := emptyClient.ParametersCalled[1]["key2"]; !ok {
+		t.Errorf("processSetStatement didn't set parameter correctly")
+	}
+	if _, ok := emptyClient.ParametersCalled[1]["key1"]; ok {
+		t.Errorf("processSetStatement used previous parameter even though query failed")
+	}
+	if len(fireboltConnection.parameters) != 0 {
+		t.Errorf("processSetStatement set parameters even though query failed")
 	}
 }
 

--- a/connection_test.go
+++ b/connection_test.go
@@ -67,6 +67,44 @@ func TestSetParameter(t *testing.T) {
 	}
 }
 
+// MockClient rudimentary mocks Client and tracks the parameters passed to Query
+type MockClient struct {
+	ParametersCalled []map[string]string
+}
+
+func (m *MockClient) Query(ctx context.Context, engineUrl, query string, parameters map[string]string, control connectionControl) (*QueryResponse, error) {
+	m.ParametersCalled = append(m.ParametersCalled, parameters)
+	return nil, nil
+}
+
+func (m *MockClient) GetConnectionParameters(ctx context.Context, engineName string, databaseName string) (string, map[string]string, error) {
+	// Implement to satisfy Client interface
+	return "", nil, nil
+}
+
+func TestMultipleSetParameters(t *testing.T) {
+	connector := FireboltConnector{}
+	emptyClient := MockClient{}
+
+	fireboltConnection := fireboltConnection{&emptyClient, "engine_url", map[string]string{}, &connector}
+
+	processSetStatement(context.TODO(), &fireboltConnection, "SET key1=value1")
+	processSetStatement(context.TODO(), &fireboltConnection, "SET key2=value")
+	// Check if parameters were set correctly
+	if len(emptyClient.ParametersCalled) != 2 {
+		t.Errorf("processSetStatement didn't set parameters correctly")
+	}
+	if _, ok := emptyClient.ParametersCalled[0]["key1"]; !ok {
+		t.Errorf("processSetStatement didn't set parameter correctly")
+	}
+	if _, ok := emptyClient.ParametersCalled[1]["key2"]; !ok {
+		t.Errorf("processSetStatement didn't set parameter correctly")
+	}
+	if _, ok := emptyClient.ParametersCalled[1]["key1"]; !ok {
+		t.Errorf("processSetStatement didn't use previous parameters correctly")
+	}
+}
+
 func TestResetParameters(t *testing.T) {
 	connector := FireboltConnector{}
 	connector.cachedParameters = map[string]string{


### PR DESCRIPTION
When using consecutive SET statements they should use all the previously defined parameters when verifying correctness, since some of the statements enable others.