### PR TITLE
refactor: FIR-35471 remove account resolve call

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ go get github.com/firebolt-db/firebolt-go-sdk
 ### Example
 Here is an example of establishing a connection and executing a simple select query. 
 For it to run successfully, you have to specify your credentials, and have a default engine up and running.
-git checkout -b FIR-35471-remove-account-resolve-endpoint-from-go-sdk
 ```go
 package main
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ go get github.com/firebolt-db/firebolt-go-sdk
 ### Example
 Here is an example of establishing a connection and executing a simple select query. 
 For it to run successfully, you have to specify your credentials, and have a default engine up and running.
-
+git checkout -b FIR-35471-remove-account-resolve-endpoint-from-go-sdk
 ```go
 package main
 

--- a/client_base.go
+++ b/client_base.go
@@ -30,7 +30,6 @@ type Client interface {
 type BaseClient struct {
 	ClientID          string
 	ClientSecret      string
-	AccountID         string
 	ApiEndpoint       string
 	UserAgent         string
 	parameterGetter   func(map[string]string) (map[string]string, error)
@@ -133,9 +132,6 @@ func (c *BaseClient) handleUpdateEndpoint(updateEndpointRaw string, control conn
 	updateEndpoint, newParameters, err := splitEngineEndpoint(updateEndpointRaw)
 	if err != nil {
 		return corruptUrlError
-	}
-	if accId, ok := newParameters["account_id"]; ok && accId[0] != c.AccountID {
-		return errors.New("Failed to execute USE ENGINE command. Account parameter mismatch. Contact support")
 	}
 	// set engine URL as a full URL excluding query parameters
 	control.setEngineURL(updateEndpoint)

--- a/client_v0.go
+++ b/client_v0.go
@@ -9,6 +9,7 @@ import (
 )
 
 type ClientImplV0 struct {
+	AccountID string
 	BaseClient
 }
 

--- a/client_v0_test.go
+++ b/client_v0_test.go
@@ -26,6 +26,7 @@ func TestCacheAccessTokenV0(t *testing.T) {
 	defer server.Close()
 	prepareEnvVariablesForTest(t, server)
 	var client = &ClientImplV0{
+		"",
 		BaseClient{ClientID: "ClientID@firebolt.io", ClientSecret: "password", ApiEndpoint: server.URL, UserAgent: "userAgent"},
 	}
 	client.accessTokenGetter = client.getAccessToken
@@ -71,6 +72,7 @@ func TestRefreshTokenOn401V0(t *testing.T) {
 	defer server.Close()
 	prepareEnvVariablesForTest(t, server)
 	var client = &ClientImplV0{
+		"",
 		BaseClient{ClientID: "ClientID@firebolt.io", ClientSecret: "password", ApiEndpoint: server.URL, UserAgent: "userAgent"},
 	}
 	client.accessTokenGetter = client.getAccessToken
@@ -108,6 +110,7 @@ func TestFetchTokenWhenExpiredV0(t *testing.T) {
 	defer server.Close()
 	prepareEnvVariablesForTest(t, server)
 	var client = &ClientImplV0{
+		"",
 		BaseClient{ClientID: "ClientID@firebolt.io", ClientSecret: "password", ApiEndpoint: server.URL, UserAgent: "userAgent"},
 	}
 	client.accessTokenGetter = client.getAccessToken
@@ -147,6 +150,7 @@ func TestUserAgentV0(t *testing.T) {
 	defer server.Close()
 	prepareEnvVariablesForTest(t, server)
 	var client = &ClientImplV0{
+		"",
 		BaseClient{ClientID: "ClientID@firebolt.io", ClientSecret: "password", ApiEndpoint: server.URL, UserAgent: userAgentValue},
 	}
 	client.accessTokenGetter = client.getAccessToken
@@ -160,6 +164,7 @@ func TestUserAgentV0(t *testing.T) {
 
 func clientFactoryV0(apiEndpoint string) Client {
 	var client = &ClientImplV0{
+		"",
 		BaseClient{ClientID: "ClientID@firebolt.io", ClientSecret: "password", ApiEndpoint: apiEndpoint},
 	}
 	client.accessTokenGetter = client.getAccessToken

--- a/driver_integration_test.go
+++ b/driver_integration_test.go
@@ -208,23 +208,6 @@ func TestDriverSystemEngineDbContext(t *testing.T) {
 	}
 }
 
-func TestIncorrectAccount(t *testing.T) {
-	_, err := Authenticate(&fireboltSettings{
-		clientID:     clientIdMock,
-		clientSecret: clientSecretMock,
-		accountName:  "incorrect_account",
-		engineName:   engineNameMock,
-		database:     databaseMock,
-		newVersion:   true,
-	}, GetHostNameURL())
-	if err == nil {
-		t.Errorf("Authentication didn't return an error, although it should")
-	}
-	if !strings.HasPrefix(err.Error(), "error during getting account id: account 'incorrect_account' does not exist") {
-		t.Errorf("Authentication didn't return an error with correct message, got: %s", err.Error())
-	}
-}
-
 // function that creates a service account and returns its id and secret
 func createServiceAccountNoUser(t *testing.T, serviceAccountName string) (string, string) {
 	serviceAccountDescription := "test_service_account_description"

--- a/urls.go
+++ b/urls.go
@@ -3,7 +3,6 @@ package fireboltgosdk
 const (
 	ServiceAccountLoginURLSuffix = "/oauth/token"
 	EngineUrlByAccountName       = "/web/v3/account/%s/engineUrl"
-	AccountInfoByAccountName     = "/web/v3/account/%s/resolve"
 	//API v0
 	UsernamePasswordURLSuffix  = "/auth/v1/login"
 	DefaultAccountURL          = "/iam/v2/account"


### PR DESCRIPTION
Removed account resolve call from the client initialization. Also removed account id validation when the endpoint is updated from the backend after USE ENGINE command