### PR TITLE
docs(FIR-36644): Clarify named parameters usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ go get github.com/firebolt-db/firebolt-go-sdk
 ```
 
 ### Example
-Here is an example of establishing a connection and executing a simple select query. 
+Here is an example of establishing a connection and executing a simple select query.
 For it to run successfully, you have to specify your credentials, and have a default engine up and running.
 ```go
 package main
@@ -42,8 +42,20 @@ func main() {
 		fmt.Println("error during opening a driver: %v", err)
 	}
 
+	// Create table
+	_, err := db.Query("CREATE TABLE test_table(id INT, value TEXT)")
+	if err != nil {
+		fmt.Println("error during select query: %v", err)
+	}
+
+	// Parametrized insert (only ? placeholders are supported)
+	_, err := db.Query("INSERT INTO test_table VALUES (?, ?)", 1, "my value")
+	if err != nil {
+		fmt.Println("error during select query: %v", err)
+	}
+
 	// executing a simple select query
-	rows, err := db.Query("SELECT 1 UNION SELECT 2")
+	rows, err := db.Query("SELECT * FROM test_table")
 	if err != nil {
 		fmt.Println("error during select query: %v", err)
 	}
@@ -62,7 +74,7 @@ func main() {
 
 
 ### DSN (Data source name)
-All information for the connection should be specified using the DSN string. The firebolt dsn string has the following format:  
+All information for the connection should be specified using the DSN string. The firebolt dsn string has the following format:
 ```
 firebolt://[/database]?account_name=account_name&client_id=client_id&client_secret=client_secret[&engine=engine]
 ```
@@ -76,3 +88,4 @@ firebolt://[/database]?account_name=account_name&client_id=client_id&client_secr
 ### Limitations
 Although, all interfaces are available, not all of them are implemented or could be implemented:
 - `driver.Result` is a dummy implementation and doesn't return the real result values.
+- Named query parameters are not supported

--- a/driver_integration_test.go
+++ b/driver_integration_test.go
@@ -294,3 +294,30 @@ func TestIncorrectQueryThrowingStructuredError(t *testing.T) {
 		t.Errorf("Query didn't return an error with correct message, got: %s", err.Error())
 	}
 }
+
+func TestParametrisedQuery(t *testing.T) {
+	ctx := context.TODO()
+	db, err := sql.Open("firebolt", dsnSystemEngineMock)
+	if err != nil {
+		t.Errorf("failed unexpectedly with %v", err)
+	}
+	query := "SELECT engine_name, status from information_schema.engines WHERE engine_name = ? AND status = ?"
+	stmt, err := db.PrepareContext(ctx, query)
+	if err != nil {
+		t.Errorf("The query %s returned an error: %v", query, err)
+	}
+	rows, err := stmt.QueryContext(ctx, engineNameMock, "RUNNING")
+	if err != nil {
+		t.Errorf("The query %s returned an error: %v", query, err)
+	}
+	if !rows.Next() {
+		t.Errorf("Next returned end of output")
+	}
+	var engineName, status string
+	if err := rows.Scan(&engineName, &status); err != nil {
+		t.Errorf("Scan returned an error: %v", err)
+	}
+	if engineName != engineNameMock || status != "RUNNING" {
+		t.Errorf("Results not equal: %s %s", engineName, status)
+	}
+}


### PR DESCRIPTION
Someone stumbled upon us not supporting named parameters. We should make it clear what kind of queries we can and can't run.