### PR TITLE
FIR-37859 use user engine for long query test

### DIFF
--- a/connection_common_integration_test.go
+++ b/connection_common_integration_test.go
@@ -384,7 +384,7 @@ func TestLongQuery(t *testing.T) {
 	finished_in := make(chan time.Duration, 1)
 	go func() {
 		started := time.Now()
-		db, err := sql.Open("firebolt", dsnSystemEngineMock)
+		db, err := sql.Open("firebolt", dsnMock)
 		if err != nil {
 			t.Errorf("failed unexpectedly with %v", err)
 		}


### PR DESCRIPTION
Updated long running test to use user engine instead of system