### PR TITLE
fix: Fir 38128 ecosystem support for struct type for go sdk

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -127,8 +127,13 @@ func checkTypeValue(columnType string, val interface{}) error {
 }
 
 func extractStructColumn(columnType string) (string, string, error) {
+	columnType = strings.TrimSpace(columnType)
+	if idx := strings.IndexRune(columnType[1:], '`'); strings.HasPrefix(columnType, "`") && idx != -1 {
+		// We use idx+2 since we found this index in the substring starting from the second character
+		return strings.Trim(columnType[1:idx+2], " `"), strings.TrimSpace(columnType[idx+2:]), nil
+	}
 	field := strings.SplitN(strings.TrimSpace(columnType), " ", 2)
-	if len(field) != 2 {
+	if len(field) < 2 {
 		return "", "", fmt.Errorf("invalid struct field: %s", columnType)
 	}
 	return strings.TrimSpace(field[0]), strings.TrimSpace(field[1]), nil

--- a/rows_test.go
+++ b/rows_test.go
@@ -276,7 +276,7 @@ func TestRowsNextSet(t *testing.T) {
 func TestRowsNextStructError(t *testing.T) {
 	rowsJson := `{
         "query":{"query_id":"16FF2A0300ECA753"},
-        "meta":[{"name":"struct_col","type":"struct(a int, s struct(b datetime))"}],
+        "meta":[{"name":"struct_col","type":"struct(a int, s struct(b timestamp))"}],
         "data":[[{"a": 1, "s": {"b": "invalid"}}]],
         "rows":1,
         "statistics":{}
@@ -296,7 +296,7 @@ func TestRowsNextStructError(t *testing.T) {
 func TestRowsNextStructWithNestedSpaces(t *testing.T) {
 	rowsJson := `{
         "query":{"query_id":"16FF2A0300ECA753"},
-        "meta":[{"name":"struct_col","type":"struct(` + "`a b`" + ` int, s struct(` + "`c d`" + ` datetime))"}],
+        "meta":[{"name":"struct_col","type":"struct(` + "`a b`" + ` int, s struct(` + "`c d`" + ` timestamp))"}],
         "data":[[{"a b": 1, "s": {"c d": "1989-04-15 01:02:03"}}]],
         "rows":1,
         "statistics":{}

--- a/rows_test.go
+++ b/rows_test.go
@@ -292,3 +292,30 @@ func TestRowsNextStructError(t *testing.T) {
 		t.Errorf("Next should return an error")
 	}
 }
+
+func TestRowsNextStructWithNestedSpaces(t *testing.T) {
+	rowsJson := `{
+        "query":{"query_id":"16FF2A0300ECA753"},
+        "meta":[{"name":"struct_col","type":"struct(` + "`a b`" + ` int, s struct(` + "`c d`" + ` datetime))"}],
+        "data":[[{"a b": 1, "s": {"c d": "1989-04-15 01:02:03"}}]],
+        "rows":1,
+        "statistics":{}
+    }`
+	var response QueryResponse
+	if err := json.Unmarshal([]byte(rowsJson), &response); err != nil {
+		panic(err)
+	}
+
+	rows := &fireboltRows{[]QueryResponse{response}, 0, 0}
+	var dest = make([]driver.Value, 1)
+	if err := rows.Next(dest); err != nil {
+		t.Errorf("Next returned an error: %s", err)
+	}
+
+	if dest[0].(map[string]driver.Value)["a b"] != int32(1) {
+		t.Errorf("results are not equal")
+	}
+	if dest[0].(map[string]driver.Value)["s"].(map[string]driver.Value)["c d"] != time.Date(1989, 04, 15, 1, 2, 3, 0, time.UTC) {
+		t.Errorf("results are not equal")
+	}
+}


### PR DESCRIPTION
Fixed support for fields with spaces in struct type