### PR TITLE
feat: FIR-42569 support quoted decimals in go sdk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,5 @@ require github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2
 require github.com/matishsiao/goInfo v0.0.0-20210923090445-da2e3fa8d45f
 
 require github.com/astaxie/beego v1.12.3
+
+require github.com/shopspring/decimal v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,8 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/shiena/ansicolor v0.0.0-20151119151921-a422bbe96644/go.mod h1:nkxAfR/5quYxwPZhyDxgasBMnRtBZd0FCEpawpjMUFg=
+github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
+github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/siddontang/go v0.0.0-20170517070808-cb568a3e5cc0/go.mod h1:3yhqj7WBBfRhbBlzyOC3gUxftwsU0u8gqevxwIHQpMw=
 github.com/siddontang/goredis v0.0.0-20150324035039-760763f78400/go.mod h1:DDcKzU3qCuvj/tPnimWSsZZzvk9qvkvrIL5naVBPh5s=
 github.com/siddontang/rdb v0.0.0-20150307021120-fc89ed2e418d/go.mod h1:AMEsy7v5z92TR1JKMkLLoaOQk++LVnOKL3ScbJ8GNGA=

--- a/rows.go
+++ b/rows.go
@@ -127,8 +127,13 @@ func checkTypeValue(columnType string, val interface{}) error {
 }
 
 func extractStructColumn(columnType string) (string, string, error) {
+	columnType = strings.TrimSpace(columnType)
+	if idx := strings.IndexRune(columnType[1:], '`'); strings.HasPrefix(columnType, "`") && idx != -1 {
+		// We use idx+2 since we found this index in the substring starting from the second character
+		return strings.Trim(columnType[1:idx+2], " `"), strings.TrimSpace(columnType[idx+2:]), nil
+	}
 	field := strings.SplitN(strings.TrimSpace(columnType), " ", 2)
-	if len(field) != 2 {
+	if len(field) < 2 {
 		return "", "", fmt.Errorf("invalid struct field: %s", columnType)
 	}
 	return strings.TrimSpace(field[0]), strings.TrimSpace(field[1]), nil

--- a/rows_test.go
+++ b/rows_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 const assertErrorMessage = "Expected: %v Got: %v"
+const nextErrorMessage = "Next returned an error: %s"
 
 func assert(testVal interface{}, expectedVal interface{}, t *testing.T, err string) {
 	if m, ok := expectedVal.(map[string]driver.Value); ok {
@@ -338,7 +339,7 @@ func TestRowsNextStructWithNestedSpaces(t *testing.T) {
 	rows := &fireboltRows{[]QueryResponse{response}, 0, 0}
 	var dest = make([]driver.Value, 1)
 	if err := rows.Next(dest); err != nil {
-		t.Errorf("Next returned an error: %s", err)
+		t.Errorf(nextErrorMessage, err)
 	}
 
 	if dest[0].(map[string]driver.Value)["a b"] != int32(1) {
@@ -355,7 +356,7 @@ func TestRowsQuotedLong(t *testing.T) {
 	rows := mockRowsSingleValue(intRaw, "long")
 	var dest = make([]driver.Value, 1)
 	if err := rows.Next(dest); err != nil {
-		t.Errorf("Next returned an error: %s", err)
+		t.Errorf(nextErrorMessage, err)
 	}
 	assert(dest[0], intValue, t, "results are not equal for long")
 }
@@ -373,7 +374,7 @@ func TestRowsDecimalType(t *testing.T) {
 		rows := mockRowsSingleValue(c[0], "Decimal(10, 35)")
 		var dest = make([]driver.Value, 1)
 		if err := rows.Next(dest); err != nil {
-			t.Errorf("Next returned an error: %s", err)
+			t.Errorf(nextErrorMessage, err)
 		}
 		assert(dest[0], c[1], t, fmt.Sprintf("results are not equal for %v", c[0]))
 	}

--- a/rows_test.go
+++ b/rows_test.go
@@ -248,9 +248,9 @@ func TestRowsNext(t *testing.T) {
 	assert(dest[2], float32(math.Inf(-1)), t, "results not equal for float32 at row 4")
 	assertDates(dest[9].(time.Time), time.Date(1111, 01, 5, 11, 11, 14, 123456000, loc), t, " at row 4")
 	assert(dest[13], false, t, "results not equal for boolean at row 4")
-	var long_double = decimal.NewFromFloat(123456781234567812345678.12345678123456781234567812345678)
-	assert(dest[14], long_double, t, "results not equal for decimal at row 4")
-	assert(dest[15].([]driver.Value), []driver.Value{long_double}, t, "results not equal for decimal array at row 4")
+	var longDouble = decimal.NewFromFloat(123456781234567812345678.12345678123456781234567812345678)
+	assert(dest[14], longDouble, t, "results not equal for decimal at row 4")
+	assert(dest[15].([]driver.Value), []driver.Value{longDouble}, t, "results not equal for decimal array at row 4")
 
 	// Fifth row
 	err = rows.Next(dest)

--- a/rows_test.go
+++ b/rows_test.go
@@ -276,7 +276,7 @@ func TestRowsNextSet(t *testing.T) {
 func TestRowsNextStructError(t *testing.T) {
 	rowsJson := `{
         "query":{"query_id":"16FF2A0300ECA753"},
-        "meta":[{"name":"struct_col","type":"struct(a int, s struct(b datetime))"}],
+        "meta":[{"name":"struct_col","type":"struct(a int, s struct(b timestamp))"}],
         "data":[[{"a": 1, "s": {"b": "invalid"}}]],
         "rows":1,
         "statistics":{}
@@ -296,7 +296,7 @@ func TestRowsNextStructError(t *testing.T) {
 func TestRowsNextStructWithNestedSpaces(t *testing.T) {
 	rowsJson := `{
         "query":{"query_id":"16FF2A0300ECA753"},
-        "meta":[{"name":"struct_col","type":"struct(` + "`a b`" + ` int, s struct(` + "`c d`" + ` datetime))"}],
+        "meta":[{"name":"struct_col","type":"struct(` + "`a b`" + ` int, s struct(` + "`c d`" + ` timestamp))"}],
         "data":[[{"a b": 1, "s": {"c d": "1989-04-15 01:02:03"}}]],
         "rows":1,
         "statistics":{}

--- a/rows_test.go
+++ b/rows_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/shopspring/decimal"
 )
 
+const assertErrorMessage = "Expected: %v Got: %v"
+
 func assert(testVal interface{}, expectedVal interface{}, t *testing.T, err string) {
 	if m, ok := expectedVal.(map[string]driver.Value); ok {
 		assertMaps(testVal.(map[string]driver.Value), m, t, err)
@@ -26,7 +28,7 @@ func assert(testVal interface{}, expectedVal interface{}, t *testing.T, err stri
 
 	} else if testVal != expectedVal {
 		t.Log(string(debug.Stack()))
-		t.Errorf(err+"Expected: %s Got: %s", expectedVal, testVal)
+		t.Errorf(err+assertErrorMessage, expectedVal, testVal)
 	}
 }
 
@@ -34,7 +36,7 @@ func assertArrays(testVal []driver.Value, expectedVal []driver.Value, t *testing
 	// manually
 	if len(testVal) != len(expectedVal) {
 		t.Log(string(debug.Stack()))
-		t.Errorf(err+"Expected: %s Got: %s", expectedVal, testVal)
+		t.Errorf(err+assertErrorMessage, expectedVal, testVal)
 	}
 	for i, value := range expectedVal {
 		assert(testVal[i], value, t, err)
@@ -45,7 +47,7 @@ func assertMaps(testVal map[string]driver.Value, expectedVal map[string]driver.V
 	// manually
 	if len(testVal) != len(expectedVal) {
 		t.Log(string(debug.Stack()))
-		t.Errorf(err+"Expected: %s Got: %s", expectedVal, testVal)
+		t.Errorf(err+assertErrorMessage, expectedVal, testVal)
 	}
 	for key, value := range expectedVal {
 		assert(testVal[key], value, t, err)
@@ -55,21 +57,21 @@ func assertMaps(testVal map[string]driver.Value, expectedVal map[string]driver.V
 func assertDates(testVal time.Time, expectedVal time.Time, t *testing.T, err string) {
 	if !testVal.Equal(expectedVal) {
 		t.Log(string(debug.Stack()))
-		t.Errorf(err+"Expected: %s Got: %s", expectedVal, testVal.In(expectedVal.Location()))
+		t.Errorf(err+assertErrorMessage, expectedVal, testVal.In(expectedVal.Location()))
 	}
 }
 
 func assertByte(testVal []byte, expectedVal []byte, t *testing.T, err string) {
 	if !bytes.Equal(testVal, expectedVal) {
 		t.Log(string(debug.Stack()))
-		t.Errorf(err+"Expected: %s Got: %s", expectedVal, testVal)
+		t.Errorf(err+assertErrorMessage, expectedVal, testVal)
 	}
 }
 
 func assertDecimal(testVal decimal.Decimal, expectedVal decimal.Decimal, t *testing.T, err string) {
 	if !testVal.Equal(expectedVal) {
 		t.Log(string(debug.Stack()))
-		t.Errorf(err+"Expected: %s Got: %s", expectedVal, testVal)
+		t.Errorf(err+assertErrorMessage, expectedVal, testVal)
 	}
 }
 
@@ -195,83 +197,83 @@ func TestRowsNext(t *testing.T) {
 	err := rows.Next(dest)
 	loc, _ := time.LoadLocation("UTC")
 
-	assert(err, nil, t, "Next shouldn't return an error")
-	assert(dest[0], nil, t, "results not equal for int32")
-	assert(dest[1], int64(1), t, "results not equal for int64")
-	assert(dest[2], float32(0.312321), t, "results not equal for float32")
-	assert(dest[3], float64(123213.321321), t, "results not equal for float64")
-	assert(dest[4], "text", t, "results not equal for string")
-	assert(dest[5], time.Date(2080, 12, 31, 0, 0, 0, 0, loc), t, "results not equal for date")
-	assert(dest[6], time.Date(1989, 04, 15, 1, 2, 3, 0, loc), t, "results not equal for datetime")
-	assert(dest[7], time.Date(0002, 01, 01, 0, 0, 0, 0, loc), t, "results not equal for pgdate")
-	assert(dest[8], time.Date(1989, 04, 15, 1, 2, 3, 123456000, loc), t, "results not equal for timestampntz")
-	assertDates(dest[9].(time.Time), time.Date(1989, 04, 15, 2, 2, 3, 123456000, loc), t, "")
-	assert(dest[13], true, t, "results not equal for boolean")
-	assert(dest[14], decimal.NewFromFloat(123.12345678), t, "results not equal for decimal")
-	assert(dest[15].([]driver.Value), []driver.Value{decimal.NewFromFloat(123.12345678)}, t, "results not equal for decimal array")
-	assertByte(dest[16].([]byte), []byte("abc123"), t, "")
-	assert(dest[17], "0101000020E6100000FEFFFFFFFFFFEF3F000000000000F03F", t, "results not equal for geography")
-	assert(dest[18].(map[string]driver.Value), map[string]driver.Value{"a": int32(1), "s": map[string]driver.Value{"a": []driver.Value{int32(1), int32(2), int32(3)}, "b": "text"}}, t, "results not equal for struct")
+	assert(err, nil, t, "Next shouldn't return an error at row 1")
+	assert(dest[0], nil, t, "results not equal for int32 at row 1")
+	assert(dest[1], int64(1), t, "results not equal for int64 at row 1")
+	assert(dest[2], float32(0.312321), t, "results not equal for float32 at row 1")
+	assert(dest[3], float64(123213.321321), t, "results not equal for float64 at row 1")
+	assert(dest[4], "text", t, "results not equal for string at row 1")
+	assert(dest[5], time.Date(2080, 12, 31, 0, 0, 0, 0, loc), t, "results not equal for date at row 1")
+	assert(dest[6], time.Date(1989, 04, 15, 1, 2, 3, 0, loc), t, "results not equal for datetime at row 1")
+	assert(dest[7], time.Date(0002, 01, 01, 0, 0, 0, 0, loc), t, "results not equal for pgdate at row 1")
+	assert(dest[8], time.Date(1989, 04, 15, 1, 2, 3, 123456000, loc), t, "results not equal for timestampntz at row 1")
+	assertDates(dest[9].(time.Time), time.Date(1989, 04, 15, 2, 2, 3, 123456000, loc), t, " at row 1")
+	assert(dest[13], true, t, "results not equal for boolean at row 1")
+	assert(dest[14], decimal.NewFromFloat(123.12345678), t, "results not equal for decimal at row 1")
+	assert(dest[15].([]driver.Value), []driver.Value{decimal.NewFromFloat(123.12345678)}, t, "results not equal for decimal array at row 1")
+	assertByte(dest[16].([]byte), []byte("abc123"), t, "results not equal for bytes at row 1")
+	assert(dest[17], "0101000020E6100000FEFFFFFFFFFFEF3F000000000000F03F", t, "results not equal for geography at row 1")
+	assert(dest[18].(map[string]driver.Value), map[string]driver.Value{"a": int32(1), "s": map[string]driver.Value{"a": []driver.Value{int32(1), int32(2), int32(3)}, "b": "text"}}, t, "results not equal for struct at row 1")
 
 	// Second row
 	err = rows.Next(dest)
-	assert(err, nil, t, "Next shouldn't return an error")
-	assert(dest[1], int64(37237366456), t, "results not equal for int64")
+	assert(err, nil, t, "Next shouldn't return an error at row 2")
+	assert(dest[1], int64(37237366456), t, "results not equal for int64 at row 2")
 	// Creating custom timezone with no name (e.g. Europe/Berlin)
 	// similar to Firebolt's return format
 	timezone, _ := time.LoadLocation("Asia/Calcutta")
-	assertDates(dest[9].(time.Time), time.Date(1989, 04, 15, 1, 2, 3, 123400000, timezone), t, "")
-	assert(dest[13], true, t, "results not equal for boolean")
-	assert(dest[14], decimal.NewFromFloat(-123.12345678), t, "results not equal for decimal")
-	assert(dest[15].([]driver.Value), []driver.Value{decimal.NewFromFloat(-123.12345678), decimal.NewFromFloat(0.0)}, t, "results not equal for decimal array")
-	assertByte(dest[16].([]byte), []byte("abc\n\nㅍ ㅎ\\"), t, "")
-	assert(dest[18].(map[string]driver.Value), map[string]driver.Value{"a": int32(2), "s": nil}, t, "results not equal for struct")
+	assertDates(dest[9].(time.Time), time.Date(1989, 04, 15, 1, 2, 3, 123400000, timezone), t, "results not equal for time at row 2")
+	assert(dest[13], true, t, "results not equal for boolean at row 2")
+	assert(dest[14], decimal.NewFromFloat(-123.12345678), t, "results not equal for decimal at row 2")
+	assert(dest[15].([]driver.Value), []driver.Value{decimal.NewFromFloat(-123.12345678), decimal.NewFromFloat(0.0)}, t, "results not equal for decimal array at row 2")
+	assertByte(dest[16].([]byte), []byte("abc\n\nㅍ ㅎ\\"), t, "results not equal for bytes at row 2")
+	assert(dest[18].(map[string]driver.Value), map[string]driver.Value{"a": int32(2), "s": nil}, t, "results not equal for struct at row 2")
 
 	// Third row
 	err = rows.Next(dest)
-	assert(err, nil, t, "Next shouldn't return an error")
-	assert(dest[0], int32(3), t, "results not equal for int32")
-	assert(dest[1], nil, t, "results not equal for int64")
-	assert(dest[2], float32(math.Inf(1)), t, "results not equal for float32")
-	assert(dest[3], float64(123213.321321), t, "results not equal for float64")
-	assert(dest[4], "text", t, "results not equal for string")
-	assert(dest[13], false, t, "results not equal for boolean")
-	assert(dest[14], decimal.NewFromFloat(0.0), t, "results not equal for decimal")
-	assert(dest[15].([]driver.Value), []driver.Value{decimal.NewFromFloat(0.0)}, t, "results not equal for decimal array")
-	assert(dest[18], nil, t, "results not equal for struct")
+	assert(err, nil, t, "Next shouldn't return an error at row 3")
+	assert(dest[0], int32(3), t, "results not equal for int32 at row 3")
+	assert(dest[1], nil, t, "results not equal for int64 at row 3")
+	assert(dest[2], float32(math.Inf(1)), t, "results not equal for float32 at row 3")
+	assert(dest[3], float64(123213.321321), t, "results not equal for float64 at row 3")
+	assert(dest[4], "text", t, "results not equal for string at row 3")
+	assert(dest[13], false, t, "results not equal for boolean at row 3")
+	assert(dest[14], decimal.NewFromFloat(0.0), t, "results not equal for decimal at row 3")
+	assert(dest[15].([]driver.Value), []driver.Value{decimal.NewFromFloat(0.0)}, t, "results not equal for decimal array at row 3")
+	assert(dest[18], nil, t, "results not equal for struct at row 3")
 
 	// Fourth row
 	err = rows.Next(dest)
-	assert(err, nil, t, "Next shouldn't return an error")
-	assert(dest[2], float32(math.Inf(-1)), t, "results not equal for float32")
-	assertDates(dest[9].(time.Time), time.Date(1111, 01, 5, 11, 11, 14, 123456000, loc), t, "")
-	assert(dest[13], false, t, "results not equal for boolean")
+	assert(err, nil, t, "Next shouldn't return an error at row 4")
+	assert(dest[2], float32(math.Inf(-1)), t, "results not equal for float32 at row 4")
+	assertDates(dest[9].(time.Time), time.Date(1111, 01, 5, 11, 11, 14, 123456000, loc), t, " at row 4")
+	assert(dest[13], false, t, "results not equal for boolean at row 4")
 	var long_double = decimal.NewFromFloat(123456781234567812345678.12345678123456781234567812345678)
-	assert(dest[14], long_double, t, "results not equal for decimal")
-	assert(dest[15].([]driver.Value), []driver.Value{long_double}, t, "results not equal for decimal array")
+	assert(dest[14], long_double, t, "results not equal for decimal at row 4")
+	assert(dest[15].([]driver.Value), []driver.Value{long_double}, t, "results not equal for decimal array at row 4")
 
 	// Fifth row
 	err = rows.Next(dest)
-	assert(err, nil, t, "Next shouldn't return an error")
+	assert(err, nil, t, "Next shouldn't return an error at row 5")
 	// Cannot do assert since NaN != NaN according to the standard
 	// math.IsNaN only works for float64, converting float32 NaN to float64 results in 0
 	if !(dest[2].(float32) != dest[2].(float32)) {
 		t.Log(string(debug.Stack()))
 		t.Errorf("results not equal for float32 Expected: NaN Got: %s", dest[2])
 	}
-	assertDates(dest[9].(time.Time), time.Date(1989, 4, 15, 3, 2, 3, 123456000, loc), t, "")
-	assert(dest[13], nil, t, "results not equal for boolean")
-	assert(dest[14], nil, t, "results not equal for decimal")
-	assert(dest[15].([]driver.Value), []driver.Value{nil}, t, "results not equal for decimal array")
+	assertDates(dest[9].(time.Time), time.Date(1989, 4, 15, 3, 2, 3, 123456000, loc), t, " at row 5")
+	assert(dest[13], nil, t, "results not equal for boolean at row 5")
+	assert(dest[14], nil, t, "results not equal for decimal at row 5")
+	assert(dest[15].([]driver.Value), []driver.Value{nil}, t, "results not equal for decimal array at row 5")
 
 	// Sixth row (does not exist)
-	assert(io.EOF, rows.Next(dest), t, "Next should return io.EOF if no data available anymore")
+	assert(io.EOF, rows.Next(dest), t, "Next should return io.EOF if no data available anymore at row 6")
 
 	// Seventh row (does not exist)
-	assert(io.EOF, rows.Next(dest), t, "Next should return io.EOF if no data available anymore")
+	assert(io.EOF, rows.Next(dest), t, "Next should return io.EOF if no data available anymore at row 7")
 
 	assert(rows.HasNextResultSet(), false, t, "Has Next result set didn't return false")
-	assert(rows.NextResultSet(), io.EOF, t, "Next result set didn't return false")
+	assert(rows.NextResultSet(), io.EOF, t, "Next result set didn't return false at the end")
 }
 
 // TestRowsNextSet check rows with multiple statements

--- a/rows_test.go
+++ b/rows_test.go
@@ -292,3 +292,30 @@ func TestRowsNextStructError(t *testing.T) {
 		t.Errorf("Next should return an error")
 	}
 }
+
+func TestRowsNextStructWithNestedSpaces(t *testing.T) {
+	rowsJson := `{
+        "query":{"query_id":"16FF2A0300ECA753"},
+        "meta":[{"name":"struct_col","type":"struct(` + "`a b`" + ` int, s struct(` + "`c d`" + ` datetime))"}],
+        "data":[[{"a b": 1, "s": {"c d": "1989-04-15 01:02:03"}}]],
+        "rows":1,
+        "statistics":{}
+    }`
+	var response QueryResponse
+	if err := json.Unmarshal([]byte(rowsJson), &response); err != nil {
+		panic(err)
+	}
+
+	rows := &fireboltRows{[]QueryResponse{response}, 0, 0}
+	var dest = make([]driver.Value, 1)
+	if err := rows.Next(dest); err != nil {
+		t.Errorf("Next returned an error: %s", err)
+	}
+
+	if dest[0].(map[string]driver.Value)["a b"] != int32(1) {
+		t.Errorf("results are not equal")
+	}
+	if dest[0].(map[string]driver.Value)["s"].(map[string]driver.Value)["c d"] != time.Date(1989, 04, 15, 1, 2, 3, 0, time.UTC) {
+		t.Errorf("results are not equal")
+	}
+}

--- a/rows_test.go
+++ b/rows_test.go
@@ -16,60 +16,60 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-func assert(test_val interface{}, expected_val interface{}, t *testing.T, err string) {
-	if m, ok := expected_val.(map[string]driver.Value); ok {
-		assertMaps(test_val.(map[string]driver.Value), m, t, err)
-	} else if arr, ok := expected_val.([]driver.Value); ok {
-		assertArrays(test_val.([]driver.Value), arr, t, err)
-	} else if d, ok := expected_val.(decimal.Decimal); ok {
-		assertDecimal(test_val.(decimal.Decimal), d, t, err)
+func assert(testVal interface{}, expectedVal interface{}, t *testing.T, err string) {
+	if m, ok := expectedVal.(map[string]driver.Value); ok {
+		assertMaps(testVal.(map[string]driver.Value), m, t, err)
+	} else if arr, ok := expectedVal.([]driver.Value); ok {
+		assertArrays(testVal.([]driver.Value), arr, t, err)
+	} else if d, ok := expectedVal.(decimal.Decimal); ok {
+		assertDecimal(testVal.(decimal.Decimal), d, t, err)
 
-	} else if test_val != expected_val {
+	} else if testVal != expectedVal {
 		t.Log(string(debug.Stack()))
-		t.Errorf(err+"Expected: %s Got: %s", expected_val, test_val)
+		t.Errorf(err+"Expected: %s Got: %s", expectedVal, testVal)
 	}
 }
 
-func assertArrays(test_val []driver.Value, expected_val []driver.Value, t *testing.T, err string) {
+func assertArrays(testVal []driver.Value, expectedVal []driver.Value, t *testing.T, err string) {
 	// manually
-	if len(test_val) != len(expected_val) {
+	if len(testVal) != len(expectedVal) {
 		t.Log(string(debug.Stack()))
-		t.Errorf(err+"Expected: %s Got: %s", expected_val, test_val)
+		t.Errorf(err+"Expected: %s Got: %s", expectedVal, testVal)
 	}
-	for i, value := range expected_val {
-		assert(test_val[i], value, t, err)
+	for i, value := range expectedVal {
+		assert(testVal[i], value, t, err)
 	}
 }
 
-func assertMaps(test_val map[string]driver.Value, expected_val map[string]driver.Value, t *testing.T, err string) {
+func assertMaps(testVal map[string]driver.Value, expectedVal map[string]driver.Value, t *testing.T, err string) {
 	// manually
-	if len(test_val) != len(expected_val) {
+	if len(testVal) != len(expectedVal) {
 		t.Log(string(debug.Stack()))
-		t.Errorf(err+"Expected: %s Got: %s", expected_val, test_val)
+		t.Errorf(err+"Expected: %s Got: %s", expectedVal, testVal)
 	}
-	for key, value := range expected_val {
-		assert(test_val[key], value, t, err)
-	}
-}
-
-func assertDates(test_val time.Time, expected_val time.Time, t *testing.T, err string) {
-	if !test_val.Equal(expected_val) {
-		t.Log(string(debug.Stack()))
-		t.Errorf(err+"Expected: %s Got: %s", expected_val, test_val.In(expected_val.Location()))
+	for key, value := range expectedVal {
+		assert(testVal[key], value, t, err)
 	}
 }
 
-func assertByte(test_val []byte, expected_val []byte, t *testing.T, err string) {
-	if !bytes.Equal(test_val, expected_val) {
+func assertDates(testVal time.Time, expectedVal time.Time, t *testing.T, err string) {
+	if !testVal.Equal(expectedVal) {
 		t.Log(string(debug.Stack()))
-		t.Errorf(err+"Expected: %s Got: %s", expected_val, test_val)
+		t.Errorf(err+"Expected: %s Got: %s", expectedVal, testVal.In(expectedVal.Location()))
 	}
 }
 
-func assertDecimal(test_val decimal.Decimal, expected_val decimal.Decimal, t *testing.T, err string) {
-	if !test_val.Equal(expected_val) {
+func assertByte(testVal []byte, expectedVal []byte, t *testing.T, err string) {
+	if !bytes.Equal(testVal, expectedVal) {
 		t.Log(string(debug.Stack()))
-		t.Errorf(err+"Expected: %s Got: %s", expected_val, test_val)
+		t.Errorf(err+"Expected: %s Got: %s", expectedVal, testVal)
+	}
+}
+
+func assertDecimal(testVal decimal.Decimal, expectedVal decimal.Decimal, t *testing.T, err string) {
+	if !testVal.Equal(expectedVal) {
+		t.Log(string(debug.Stack()))
+		t.Errorf(err+"Expected: %s Got: %s", expectedVal, testVal)
 	}
 }
 


### PR DESCRIPTION
- Added support for decimal type, both as a float and as a string value.
- Added test cases for bigint value returned as a string