### PR TITLE
Fir 44128 report column types in go sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ All information for the connection should be specified using the DSN string. The
 firebolt://[/database]?account_name=account_name&client_id=client_id&client_secret=client_secret[&engine=engine]
 ```
 
-- **client_id** - credentials client id.
-- **client_secret** - credentials client secret.
+- **client_id** - client id of the [service account](https://docs.firebolt.io/sql_reference/information-schema/service-accounts.html).
+- **client_secret** - client secret of the [service account](https://docs.firebolt.io/sql_reference/information-schema/service-accounts.html).
 - **account_name** - the name of Firebolt account to log in to.
 - **database** - (optional) the name of the database to connect to.
 - **engine** - (optional) the name of the engine to run SQL on.

--- a/connection_common_integration_test.go
+++ b/connection_common_integration_test.go
@@ -8,11 +8,14 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"math"
 	"os"
 	"reflect"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/shopspring/decimal"
 
 	contextUtils "github.com/firebolt-db/firebolt-go-sdk/context"
 
@@ -472,4 +475,108 @@ func TestStreamMultipleDataBlocks(t *testing.T) {
 		t.Errorf("Next() call returned true, but it should return false")
 	}
 
+}
+
+type columnType struct {
+	Name              string
+	DatabaseTypeName  string
+	ScanType          reflect.Type
+	HasNullable       bool
+	Nullable          bool
+	HasLength         bool
+	Length            int64
+	HasPrecisionScale bool
+	Precision         int64
+	Scale             int64
+}
+
+func getExpectedColumnTypes(isStreaming bool) []columnType {
+	res := []columnType{
+		{"col_int", "int", reflect.TypeOf(int32(0)), true, false, false, 0, false, 0, 0},
+		{"col_long", "long", reflect.TypeOf(int64(0)), true, false, false, 0, false, 0, 0},
+		{"col_float", "float", reflect.TypeOf(float32(0)), true, false, false, 0, false, 0, 0},
+		{"col_double", "double", reflect.TypeOf(float64(0)), true, false, false, 0, false, 0, 0},
+		{"col_text", "text", reflect.TypeOf(""), true, false, true, math.MaxInt64, false, 0, 0},
+		{"col_date", "date", reflect.TypeOf(time.Time{}), true, false, false, 0, false, 0, 0},
+		{"col_timestamp", "timestamp", reflect.TypeOf(time.Time{}), true, false, false, 0, false, 0, 0},
+		{"col_timestamptz", "timestamptz", reflect.TypeOf(time.Time{}), true, false, false, 0, false, 0, 0},
+		{"col_boolean", "boolean", reflect.TypeOf(true), true, false, false, 0, false, 0, 0},
+		{"col_array", "array(int)", reflect.TypeOf([]int32{}), true, false, true, math.MaxInt64, false, 0, 0},
+		{"col_decimal", "Decimal(38, 30)", reflect.TypeOf(decimal.Decimal{}), true, false, false, 0, true, 38, 30},
+		{"col_bytea", "bytea", reflect.TypeOf([]byte{}), true, false, true, math.MaxInt64, false, 0, 0},
+		{"col_geography", "geography", reflect.TypeOf(""), true, false, false, 0, false, 0, 0},
+		{"col_nullable", "text", reflect.TypeOf(""), true, true, true, math.MaxInt64, false, 0, 0},
+	}
+	// Some types are returned by different alias from database when streaming
+	if isStreaming {
+		res[0].DatabaseTypeName = "integer"
+		res[1].DatabaseTypeName = "bigint"
+		res[2].DatabaseTypeName = "real"
+		res[3].DatabaseTypeName = "double precision"
+		res[9].DatabaseTypeName = "array(integer)"
+		res[10].DatabaseTypeName = "numeric(38, 30)"
+	}
+	return res
+}
+
+func TestResponseMetadata(t *testing.T) {
+	const selectAllTypesSQL = `
+       select 1                                                  as col_int,
+       30000000000                                               as col_long,
+       1.23::FLOAT4                                              as col_float,
+       1.23456789012                                             as col_double,
+       'text'                                                    as col_text,
+       '2021-03-28'::date                                        as col_date,
+       '2019-07-31 01:01:01'::timestamp                          as col_timestamp,
+       '1111-01-05 17:04:42.123456'::timestamptz                 as col_timestamptz,
+       true                                                      as col_boolean,
+       [1,2,3,4]                                                 as col_array,
+       '1231232.123459999990457054844258706536'::decimal(38, 30) as col_decimal,
+       'abc123'::bytea                                           as col_bytea,
+       'point(1 2)'::geography                                   as col_geography,
+       null                                                      as col_nullable;`
+
+	utils.RunInMemoryAndStream(t, func(t *testing.T, ctx context.Context) {
+		expectedColumnTypes := getExpectedColumnTypes(contextUtils.IsStreaming(ctx))
+
+		conn, err := sql.Open("firebolt", dsnMock)
+		if err != nil {
+			t.Errorf(OPEN_CONNECTION_ERROR_MSG)
+			t.FailNow()
+		}
+
+		rows, err := conn.QueryContext(ctx, selectAllTypesSQL)
+		if err != nil {
+			t.Errorf(STATEMENT_ERROR_MSG, err)
+			t.FailNow()
+		}
+
+		if !rows.Next() {
+			t.Errorf("Next() call returned false with error: %v", rows.Err())
+			t.FailNow()
+		}
+
+		types, err := rows.ColumnTypes()
+		if err != nil {
+			t.Errorf("ColumnTypes returned an error, but shouldn't")
+			t.FailNow()
+		}
+
+		for i, ct := range types {
+			utils.AssertEqual(ct.Name(), expectedColumnTypes[i].Name, t, fmt.Sprintf("column name is not equal for column %s", ct.Name()))
+			utils.AssertEqual(ct.DatabaseTypeName(), expectedColumnTypes[i].DatabaseTypeName, t, fmt.Sprintf("database type name is not equal for column %s", ct.Name()))
+			utils.AssertEqual(ct.ScanType(), expectedColumnTypes[i].ScanType, t, fmt.Sprintf("scan type is not equal for column %s", ct.Name()))
+			nullable, ok := ct.Nullable()
+			utils.AssertEqual(ok, expectedColumnTypes[i].HasNullable, t, fmt.Sprintf("nullable ok is not equal for column %s", ct.Name()))
+			utils.AssertEqual(nullable, expectedColumnTypes[i].Nullable, t, fmt.Sprintf("nullable is not equal for column %s", ct.Name()))
+			length, ok := ct.Length()
+			utils.AssertEqual(ok, expectedColumnTypes[i].HasLength, t, fmt.Sprintf("length ok is not equal for column %s", ct.Name()))
+			utils.AssertEqual(length, expectedColumnTypes[i].Length, t, fmt.Sprintf("length is not equal for column %s", ct.Name()))
+			precision, scale, ok := ct.DecimalSize()
+			utils.AssertEqual(ok, expectedColumnTypes[i].HasPrecisionScale, t, fmt.Sprintf("precision scale ok is not equal for column %s", ct.Name()))
+			utils.AssertEqual(precision, expectedColumnTypes[i].Precision, t, fmt.Sprintf("precision is not equal for column %s", ct.Name()))
+			utils.AssertEqual(scale, expectedColumnTypes[i].Scale, t, fmt.Sprintf("scale is not equal for column %s", ct.Name()))
+		}
+
+	})
 }

--- a/rows/column_reader.go
+++ b/rows/column_reader.go
@@ -1,9 +1,34 @@
 package rows
 
-import "github.com/firebolt-db/firebolt-go-sdk/types"
+import (
+	"reflect"
+
+	"github.com/firebolt-db/firebolt-go-sdk/types"
+)
+
+type columnRecord struct {
+	name   string
+	fbType fireboltType
+}
 
 type ColumnReader struct {
-	columns []types.Column
+	columns []columnRecord
+}
+
+func (r *ColumnReader) setColumns(columns []types.Column) error {
+	r.columns = make([]columnRecord, len(columns))
+	for i, column := range columns {
+		fbType, err := parseType(column.Type)
+		if err != nil {
+			return err
+		}
+		r.columns[i] = columnRecord{
+			name:   column.Name,
+			fbType: fbType,
+		}
+	}
+	return nil
+
 }
 
 // Columns returns a list of column names in the current row set
@@ -12,8 +37,34 @@ func (r *ColumnReader) Columns() []string {
 	result := make([]string, 0, numColumns)
 
 	for _, column := range r.columns {
-		result = append(result, column.Name)
+		result = append(result, column.name)
 	}
 
 	return result
+}
+
+func (r *ColumnReader) ColumnTypeScanType(index int) reflect.Type {
+	return r.columns[index].fbType.goType
+}
+
+func (r *ColumnReader) ColumnTypeDatabaseTypeName(index int) string {
+	return r.columns[index].fbType.dbName
+}
+
+func (r *ColumnReader) ColumnTypeNullable(index int) (nullable, ok bool) {
+	return r.columns[index].fbType.isNullable, true
+}
+
+func (r *ColumnReader) ColumnTypeLength(index int) (length int64, ok bool) {
+	if r.columns[index].fbType.length > 0 {
+		return r.columns[index].fbType.length, true
+	}
+	return 0, false
+}
+
+func (r *ColumnReader) ColumnTypePrecisionScale(index int) (precision, scale int64, ok bool) {
+	if r.columns[index].fbType.precision > 0 && r.columns[index].fbType.scale > 0 {
+		return r.columns[index].fbType.precision, r.columns[index].fbType.scale, true
+	}
+	return 0, 0, false
 }

--- a/rows/column_reader.go
+++ b/rows/column_reader.go
@@ -1,0 +1,19 @@
+package rows
+
+import "github.com/firebolt-db/firebolt-go-sdk/types"
+
+type ColumnReader struct {
+	columns []types.Column
+}
+
+// Columns returns a list of column names in the current row set
+func (r *ColumnReader) Columns() []string {
+	numColumns := len(r.columns)
+	result := make([]string, 0, numColumns)
+
+	for _, column := range r.columns {
+		result = append(result, column.Name)
+	}
+
+	return result
+}

--- a/rows/column_reader_test.go
+++ b/rows/column_reader_test.go
@@ -202,6 +202,16 @@ var testCases = []columnReaderTestCase{
 		expectedPrecision:  -1,
 		expectedScale:      -1,
 	},
+	{
+		column:             types.Column{Name: "col_struct", Type: "struct(a int null, s struct(a array(int) null, b text null) null) null"},
+		expectedName:       "col_struct",
+		expectedType:       reflect.TypeOf(map[string]interface{}{}),
+		expectedDBTypeName: "struct(a int null, s struct(a array(int) null, b text null) null)",
+		expectedNullable:   true,
+		expectedLength:     -1,
+		expectedPrecision:  -1,
+		expectedScale:      -1,
+	},
 }
 
 func testColumns() []types.Column {

--- a/rows/column_reader_test.go
+++ b/rows/column_reader_test.go
@@ -1,0 +1,296 @@
+package rows
+
+import (
+	"math"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/firebolt-db/firebolt-go-sdk/types"
+	"github.com/shopspring/decimal"
+)
+
+type columnReaderTestCase struct {
+	column             types.Column
+	expectedName       string
+	expectedType       reflect.Type
+	expectedDBTypeName string
+	expectedNullable   bool
+	expectedLength     int64
+	expectedPrecision  int64
+	expectedScale      int64
+}
+
+var testCases = []columnReaderTestCase{
+	{
+		column:             types.Column{Name: "col_int", Type: "int"},
+		expectedName:       "col_int",
+		expectedType:       reflect.TypeOf(int32(0)),
+		expectedDBTypeName: "int",
+		expectedNullable:   false,
+		expectedLength:     -1,
+		expectedPrecision:  -1,
+		expectedScale:      -1,
+	},
+	{
+		column:             types.Column{Name: "col_int_null", Type: "int null"},
+		expectedName:       "col_int_null",
+		expectedType:       reflect.TypeOf(int32(0)),
+		expectedDBTypeName: "int",
+		expectedNullable:   true,
+		expectedLength:     -1,
+		expectedPrecision:  -1,
+		expectedScale:      -1,
+	},
+	{
+		column:             types.Column{Name: "col_integer", Type: "integer"},
+		expectedName:       "col_integer",
+		expectedType:       reflect.TypeOf(int32(0)),
+		expectedDBTypeName: "integer",
+		expectedNullable:   false,
+		expectedLength:     -1,
+		expectedPrecision:  -1,
+		expectedScale:      -1,
+	},
+	{
+		column:             types.Column{Name: "col_long", Type: "long"},
+		expectedName:       "col_long",
+		expectedType:       reflect.TypeOf(int64(0)),
+		expectedDBTypeName: "long",
+		expectedNullable:   false,
+		expectedLength:     -1,
+		expectedPrecision:  -1,
+		expectedScale:      -1,
+	},
+	{
+		column:             types.Column{Name: "col_bigint", Type: "bigint"},
+		expectedName:       "col_bigint",
+		expectedType:       reflect.TypeOf(int64(0)),
+		expectedDBTypeName: "bigint",
+		expectedNullable:   false,
+		expectedLength:     -1,
+		expectedPrecision:  -1,
+		expectedScale:      -1,
+	},
+	{
+		column:             types.Column{Name: "col_float", Type: "float"},
+		expectedName:       "col_float",
+		expectedType:       reflect.TypeOf(float32(0)),
+		expectedDBTypeName: "float",
+		expectedNullable:   false,
+		expectedLength:     -1,
+		expectedPrecision:  -1,
+		expectedScale:      -1,
+	},
+	{
+		column:             types.Column{Name: "col_double", Type: "double"},
+		expectedName:       "col_double",
+		expectedType:       reflect.TypeOf(float64(0)),
+		expectedDBTypeName: "double",
+		expectedNullable:   false,
+		expectedLength:     -1,
+		expectedPrecision:  -1,
+		expectedScale:      -1,
+	},
+	{
+		column:             types.Column{Name: "col_double_precision", Type: "double precision"},
+		expectedName:       "col_double_precision",
+		expectedType:       reflect.TypeOf(float64(0)),
+		expectedDBTypeName: "double precision",
+		expectedNullable:   false,
+		expectedLength:     -1,
+		expectedPrecision:  -1,
+		expectedScale:      -1,
+	},
+	{
+		column:             types.Column{Name: "col_text", Type: "text"},
+		expectedName:       "col_text",
+		expectedType:       reflect.TypeOf(""),
+		expectedDBTypeName: "text",
+		expectedNullable:   false,
+		expectedLength:     math.MaxInt,
+		expectedPrecision:  -1,
+		expectedScale:      -1,
+	},
+	{
+		column:             types.Column{Name: "col_date", Type: "date"},
+		expectedName:       "col_date",
+		expectedType:       reflect.TypeOf(time.Time{}),
+		expectedDBTypeName: "date",
+		expectedNullable:   false,
+		expectedLength:     -1,
+		expectedPrecision:  -1,
+		expectedScale:      -1,
+	},
+	{
+		column:             types.Column{Name: "col_timestamp", Type: "timestamp"},
+		expectedName:       "col_timestamp",
+		expectedType:       reflect.TypeOf(time.Time{}),
+		expectedDBTypeName: "timestamp",
+		expectedNullable:   false,
+		expectedLength:     -1,
+		expectedPrecision:  -1,
+		expectedScale:      -1,
+	},
+	{
+		column:             types.Column{Name: "col_timestamptz", Type: "timestamptz"},
+		expectedName:       "col_timestamptz",
+		expectedType:       reflect.TypeOf(time.Time{}),
+		expectedDBTypeName: "timestamptz",
+		expectedNullable:   false,
+		expectedLength:     -1,
+		expectedPrecision:  -1,
+		expectedScale:      -1,
+	},
+	{
+		column:             types.Column{Name: "col_boolean", Type: "boolean"},
+		expectedName:       "col_boolean",
+		expectedType:       reflect.TypeOf(true),
+		expectedDBTypeName: "boolean",
+		expectedNullable:   false,
+		expectedLength:     -1,
+		expectedPrecision:  -1,
+		expectedScale:      -1,
+	},
+	{
+		column:             types.Column{Name: "col_array", Type: "array(int)"},
+		expectedName:       "col_array",
+		expectedType:       reflect.TypeOf([]int32{}),
+		expectedDBTypeName: "array(int)",
+		expectedNullable:   false,
+		expectedLength:     math.MaxInt,
+		expectedPrecision:  -1,
+		expectedScale:      -1,
+	},
+	{
+		column:             types.Column{Name: "col_decimal", Type: "Decimal(14, 22)"},
+		expectedName:       "col_decimal",
+		expectedType:       reflect.TypeOf(decimal.Decimal{}),
+		expectedDBTypeName: "Decimal(14, 22)",
+		expectedNullable:   false,
+		expectedLength:     -1,
+		expectedPrecision:  14,
+		expectedScale:      22,
+	},
+	{
+		column:             types.Column{Name: "col_numeric", Type: "numeric(17, 8) null"},
+		expectedName:       "col_numeric",
+		expectedType:       reflect.TypeOf(decimal.Decimal{}),
+		expectedDBTypeName: "numeric(17, 8)",
+		expectedNullable:   true,
+		expectedLength:     -1,
+		expectedPrecision:  17,
+		expectedScale:      8,
+	},
+	{
+		column:             types.Column{Name: "col_bytea", Type: "bytea"},
+		expectedName:       "col_bytea",
+		expectedType:       reflect.TypeOf([]byte{}),
+		expectedDBTypeName: "bytea",
+		expectedNullable:   false,
+		expectedLength:     math.MaxInt,
+		expectedPrecision:  -1,
+		expectedScale:      -1,
+	},
+	{
+		column:             types.Column{Name: "col_geography", Type: "geography"},
+		expectedName:       "col_geography",
+		expectedType:       reflect.TypeOf(""),
+		expectedDBTypeName: "geography",
+		expectedNullable:   false,
+		expectedLength:     -1,
+		expectedPrecision:  -1,
+		expectedScale:      -1,
+	},
+}
+
+func testColumns() []types.Column {
+	columns := make([]types.Column, len(testCases))
+	for i, tc := range testCases {
+		columns[i] = tc.column
+	}
+	return columns
+}
+
+func TestColumnReader_Columns(t *testing.T) {
+	c := &ColumnReader{}
+	must(c.setColumns(testColumns()))
+
+	for i, tc := range testCases {
+		if got := c.Columns()[i]; got != tc.expectedName {
+			t.Errorf("Expected column name %s, got %s for column %s", tc.expectedName, got, tc.column.Name)
+		}
+	}
+}
+
+func TestColumnReader_ColumnTypeScanType(t *testing.T) {
+	c := &ColumnReader{}
+	must(c.setColumns(testColumns()))
+
+	for i, tc := range testCases {
+		if got := c.ColumnTypeScanType(i); got != tc.expectedType {
+			t.Errorf("Expected type %v, got %v for column %s", tc.expectedType, got, tc.column.Name)
+		}
+	}
+}
+
+func TestColumnReader_ColumnTypeDatabaseTypeName(t *testing.T) {
+	c := &ColumnReader{}
+	must(c.setColumns(testColumns()))
+
+	for i, tc := range testCases {
+		if got := c.ColumnTypeDatabaseTypeName(i); got != tc.expectedDBTypeName {
+			t.Errorf("Expected database type %s, got %s for column %s", tc.expectedDBTypeName, got, tc.column.Name)
+		}
+	}
+}
+
+func TestColumnReader_ColumnTypeNullable(t *testing.T) {
+	c := &ColumnReader{}
+	must(c.setColumns(testColumns()))
+
+	for i, tc := range testCases {
+		if got, ok := c.ColumnTypeNullable(i); got != tc.expectedNullable || !ok {
+			t.Errorf("Expected nullable %t, got %t for column %s", tc.expectedNullable, got, tc.column.Name)
+		}
+	}
+}
+
+func TestColumnReader_ColumnTypeLength(t *testing.T) {
+	c := &ColumnReader{}
+	must(c.setColumns(testColumns()))
+
+	for i, tc := range testCases {
+		expectedLength := tc.expectedLength
+		expectedOk := true
+		if tc.expectedLength == -1 {
+			expectedLength = 0
+			expectedOk = false
+		}
+		if got, ok := c.ColumnTypeLength(i); got != expectedLength || ok != expectedOk {
+			t.Errorf("Expected length %d, ok %v, got length %d, ok %v for column %s", expectedLength, expectedOk, got, ok, tc.column.Name)
+		}
+	}
+}
+
+func TestColumnReader_ColumnTypePrecisionScale(t *testing.T) {
+	c := &ColumnReader{}
+	must(c.setColumns(testColumns()))
+
+	for i, tc := range testCases {
+		expectedPrecision := tc.expectedPrecision
+		expectedScale := tc.expectedScale
+		expectedOk := true
+		if tc.expectedPrecision == -1 || tc.expectedScale == -1 {
+			expectedPrecision = 0
+			expectedScale = 0
+			expectedOk = false
+		}
+		if gotPrecision, gotScale, ok := c.ColumnTypePrecisionScale(i); gotPrecision != expectedPrecision || gotScale != expectedScale || ok != expectedOk {
+			t.Errorf(
+				"Expected precision %d, scale %d, ok %v, got precision %d, scale %d, ok %v for column %s",
+				expectedPrecision, expectedScale, expectedOk, gotPrecision, gotScale, ok, tc.column.Name,
+			)
+		}
+	}
+}

--- a/rows/common_tests.go
+++ b/rows/common_tests.go
@@ -167,7 +167,7 @@ func testRowsNextStructError(t *testing.T, rowsFactory func(isMultiStatement boo
 		panic(err)
 	}
 
-	rows := &InMemoryRows{[]types.QueryResponse{response}, 0, 0}
+	rows := &InMemoryRows{ColumnReader{}, []types.QueryResponse{response}, 0, 0}
 	var dest = make([]driver.Value, 1)
 	if err := rows.Next(dest); err == nil {
 		t.Errorf("Next should return an error")
@@ -187,7 +187,7 @@ func testRowsNextStructWithNestedSpaces(t *testing.T, rowsFactory func(isMultiSt
 		panic(err)
 	}
 
-	rows := &InMemoryRows{[]types.QueryResponse{response}, 0, 0}
+	rows := &InMemoryRows{ColumnReader{}, []types.QueryResponse{response}, 0, 0}
 	var dest = make([]driver.Value, 1)
 	if err := rows.Next(dest); err != nil {
 		t.Errorf(nextErrorMessage, err)

--- a/rows/in_memory_rows.go
+++ b/rows/in_memory_rows.go
@@ -14,21 +14,10 @@ import (
 )
 
 type InMemoryRows struct {
+	ColumnReader
 	queryResponses    []types.QueryResponse
 	cursorPosition    int
 	resultSetPosition int
-}
-
-// Columns returns a list of Meta names in response
-func (r *InMemoryRows) Columns() []string {
-	numColumns := len(r.queryResponses[r.resultSetPosition].Meta)
-	result := make([]string, 0, numColumns)
-
-	for _, column := range r.queryResponses[r.resultSetPosition].Meta {
-		result = append(result, column.Name)
-	}
-
-	return result
 }
 
 // Close makes the rows unusable
@@ -69,6 +58,7 @@ func (r *InMemoryRows) NextResultSet() error {
 
 	r.cursorPosition = 0
 	r.resultSetPosition += 1
+	r.columns = r.queryResponses[r.resultSetPosition].Meta
 
 	return nil
 }
@@ -85,7 +75,7 @@ func (r *InMemoryRows) ProcessAndAppendResponse(response *client.Response) error
 		return errors.ConstructNestedError("error during reading response content", err)
 	}
 	if err := json.Unmarshal(content, &errorResponse); err == nil {
-		if errorResponse.Errors != nil {
+		if len(errorResponse.Errors) > 0 {
 			return errors.NewStructuredError(errorResponse.Errors)
 		}
 	}
@@ -101,5 +91,9 @@ func (r *InMemoryRows) ProcessAndAppendResponse(response *client.Response) error
 	}
 
 	r.queryResponses = append(r.queryResponses, queryResponse)
+	if r.columns == nil {
+		r.columns = r.queryResponses[r.resultSetPosition].Meta
+	}
+
 	return nil
 }

--- a/rows/in_memory_rows.go
+++ b/rows/in_memory_rows.go
@@ -58,9 +58,7 @@ func (r *InMemoryRows) NextResultSet() error {
 
 	r.cursorPosition = 0
 	r.resultSetPosition += 1
-	r.columns = r.queryResponses[r.resultSetPosition].Meta
-
-	return nil
+	return r.setColumns(r.queryResponses[r.resultSetPosition].Meta)
 }
 
 // AppendResponse appends the response to the InMemoryRows, parsing the response content
@@ -92,7 +90,7 @@ func (r *InMemoryRows) ProcessAndAppendResponse(response *client.Response) error
 
 	r.queryResponses = append(r.queryResponses, queryResponse)
 	if r.columns == nil {
-		r.columns = r.queryResponses[r.resultSetPosition].Meta
+		return r.setColumns(r.queryResponses[r.resultSetPosition].Meta)
 	}
 
 	return nil

--- a/rows/stream_rows.go
+++ b/rows/stream_rows.go
@@ -14,10 +14,10 @@ import (
 )
 
 type StreamRows struct {
+	ColumnReader
 	responses         []*client.Response
 	resultSetPosition int
 	// current row
-	columns          []types.Column
 	rowReader        *bufio.Reader
 	dataBuffer       [][]interface{}
 	dataBufferCursor int


### PR DESCRIPTION
Added types reporting for both inMemory and streaming rows.
For every column we now report
- go-native type (reflect.Type)
- database-native type name
- is type nullable
- type length (maxInt for text, bytea and array, 0 for all others)
- precision/scale (non-zero for Decimal only)