### PR TITLE
fix: FIR-44362 split driver client options 

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -52,7 +52,7 @@ func MakeClient(settings *types.FireboltSettings, apiEndpoint string) (*ClientIm
 			ClientSecret: settings.ClientSecret,
 			ApiEndpoint:  apiEndpoint,
 			UserAgent:    ConstructUserAgentString(),
-			newVersion:   settings.NewVersion,
+			newVersion:   true,
 		},
 		AccountName: settings.AccountName,
 	}

--- a/client/client_v0.go
+++ b/client/client_v0.go
@@ -25,7 +25,7 @@ func MakeClientV0(settings *types.FireboltSettings, apiEndpoint string) (*Client
 			ClientSecret: settings.ClientSecret,
 			ApiEndpoint:  apiEndpoint,
 			UserAgent:    ConstructUserAgentString(),
-			newVersion:   settings.NewVersion,
+			newVersion:   false,
 		},
 	}
 	client.ParameterGetter = client.getQueryParams

--- a/driver_options_test.go
+++ b/driver_options_test.go
@@ -38,3 +38,36 @@ func TestDriverOptions(t *testing.T) {
 
 	utils.AssertEqual(tok, token, t, "token getter returned wrong token")
 }
+
+func TestDriverOptionsSeparateClientParams(t *testing.T) {
+	engineUrl := "https://engine.url"
+	databaseName := "database_name"
+	accountID := "account-id"
+	token := "1234567890"
+	userAgent := "UA Test"
+
+	conn := FireboltConnectorWithOptions(
+		WithEngineUrl(engineUrl),
+		WithDatabaseName(databaseName),
+		WithAccountID(accountID),
+		WithToken(token),
+		WithUserAgent(userAgent),
+	)
+
+	utils.AssertEqual(conn.engineUrl, engineUrl, t, "engineUrl is invalid")
+	utils.AssertEqual(conn.cachedParameters["database"], databaseName, t, "databaseName is invalid")
+
+	cl, ok := conn.client.(*client.ClientImpl)
+	utils.AssertEqual(ok, true, t, "client is not *ClientImpl")
+
+	connectionAccountID := conn.cachedParameters["account_id"]
+	utils.AssertEqual(connectionAccountID, accountID, t, "accountID is invalid")
+	utils.AssertEqual(cl.UserAgent, userAgent, t, "userAgent is invalid")
+
+	tok, err := cl.AccessTokenGetter()
+	if err != nil {
+		t.Errorf("token getter returned an error: %v", err)
+	}
+
+	utils.AssertEqual(tok, token, t, "token getter returned wrong token")
+}


### PR DESCRIPTION
A couple of improvements for pg_fire
1. Hardcoded newVersion value for every client type. Otherwise we got into a situation, where we has ClientImpl have newVersion=false, which caused issues when streaming
2. Split driver client options into three different function for a more granular control