### PR TITLE
fix: Fir 44362 fix streaming with driver options

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -52,7 +52,6 @@ func MakeClient(settings *types.FireboltSettings, apiEndpoint string) (*ClientIm
 			ClientSecret: settings.ClientSecret,
 			ApiEndpoint:  apiEndpoint,
 			UserAgent:    ConstructUserAgentString(),
-			newVersion:   true,
 		},
 		AccountName: settings.AccountName,
 	}

--- a/client/client_base.go
+++ b/client/client_base.go
@@ -27,7 +27,6 @@ var allowedUpdateParameters = []string{"database"}
 type Client interface {
 	GetConnectionParameters(ctx context.Context, engineName string, databaseName string) (string, map[string]string, error)
 	Query(ctx context.Context, engineUrl, query string, parameters map[string]string, control ConnectionControl) (*Response, error)
-	IsNewVersion() bool
 }
 
 type BaseClient struct {
@@ -37,7 +36,6 @@ type BaseClient struct {
 	UserAgent         string
 	ParameterGetter   func(context.Context, map[string]string) (map[string]string, error)
 	AccessTokenGetter func() (string, error)
-	newVersion        bool
 }
 
 // ConnectionControl is a struct that holds methods for updating connection properties
@@ -46,11 +44,6 @@ type ConnectionControl struct {
 	UpdateParameters func(string, string)
 	ResetParameters  func()
 	SetEngineURL     func(string)
-}
-
-// IsNewVersion returns true if the client is using the 2.0 version of Firebolt
-func (c *BaseClient) IsNewVersion() bool {
-	return c.newVersion
 }
 
 // Query sends a query to the engine URL and populates queryResponse, if query was successful

--- a/client/client_v0.go
+++ b/client/client_v0.go
@@ -25,7 +25,6 @@ func MakeClientV0(settings *types.FireboltSettings, apiEndpoint string) (*Client
 			ClientSecret: settings.ClientSecret,
 			ApiEndpoint:  apiEndpoint,
 			UserAgent:    ConstructUserAgentString(),
-			newVersion:   false,
 		},
 	}
 	client.ParameterGetter = client.getQueryParams

--- a/connection.go
+++ b/connection.go
@@ -57,7 +57,8 @@ func (c *fireboltConnection) QueryContext(ctx context.Context, query string, arg
 
 func (c *fireboltConnection) makeRows(ctx context.Context) rows.ExtendableRows {
 	isStreaming := contextUtils.IsStreaming(ctx)
-	if isStreaming && c.client.IsNewVersion() {
+	_, isNewVersion := c.client.(*client.ClientImpl)
+	if isStreaming && isNewVersion {
 		return &rows.StreamRows{}
 	}
 	return &rows.InMemoryRows{}

--- a/driver_options_integration_test.go
+++ b/driver_options_integration_test.go
@@ -8,6 +8,8 @@ import (
 	"database/sql/driver"
 	"testing"
 
+	contextUtils "github.com/firebolt-db/firebolt-go-sdk/context"
+
 	"github.com/firebolt-db/firebolt-go-sdk/rows"
 
 	"github.com/firebolt-db/firebolt-go-sdk/client"
@@ -73,7 +75,7 @@ func TestFireboltConnectorWithOptions(t *testing.T) {
 	utils.AssertEqual(values[0], int32(1), t, "result is not 1")
 }
 
-func TestFireboltConnectorWithASeparatedOptions(t *testing.T) {
+func makeConnectionWithSeparatedOptions(t *testing.T) *FireboltConnector {
 	cl, err := client.ClientFactory(&types.FireboltSettings{
 		ClientID:     clientIdMock,
 		ClientSecret: clientSecretMock,
@@ -102,13 +104,17 @@ func TestFireboltConnectorWithASeparatedOptions(t *testing.T) {
 
 	accountID, _ := engineParameters["account_id"]
 
-	conn := FireboltConnectorWithOptions(
+	return FireboltConnectorWithOptions(
 		WithEngineUrl(engineUrl),
 		WithDatabaseName(databaseMock),
 		WithAccountID(accountID),
 		WithToken(token),
 		WithUserAgent(userAgent),
 	)
+}
+
+func TestFireboltConnectorWithASeparatedOptions(t *testing.T) {
+	conn := makeConnectionWithSeparatedOptions(t)
 
 	resp, err := conn.client.Query(context.Background(), conn.engineUrl, "SELECT 1", nil, client.ConnectionControl{})
 	if err != nil {
@@ -119,6 +125,34 @@ func TestFireboltConnectorWithASeparatedOptions(t *testing.T) {
 	rows := rows.InMemoryRows{}
 	if err := rows.ProcessAndAppendResponse(resp); err != nil {
 		t.Errorf("failed to process response: %v", err)
+		t.FailNow()
+	}
+
+	var values []driver.Value = make([]driver.Value, len(rows.Columns()))
+
+	if err := rows.Next(values); err != nil {
+		t.Errorf("failed to get result: %v", err)
+		t.FailNow()
+	}
+
+	utils.AssertEqual(len(values), 1, t, "returned more that one value")
+	utils.AssertEqual(values[0], int32(1), t, "result is not 1")
+}
+
+func TestFireboltConnectorStreamingWithOptions(t *testing.T) {
+	db := makeConnectionWithSeparatedOptions(t)
+
+	c, err := db.Connect(context.Background())
+	if err != nil {
+		t.Errorf("failed to connect: %v", err)
+		t.FailNow()
+	}
+
+	conn := c.(*fireboltConnection)
+
+	rows, err := conn.QueryContext(contextUtils.WithStreaming(context.Background()), "SELECT 1", nil)
+	if err != nil {
+		t.Errorf("failed to query: %v", err)
 		t.FailNow()
 	}
 


### PR DESCRIPTION
Fix issue with client not being initialized properly in ConnectorWithOptions method. This caused v2 client to set newVersion=false, which caused integrity issues during streaming (client requested streaming, but tried to read the response with inMemory rows)