### PR TITLE
feat: FIR-44820 add typed errors to go sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ func main() {
     invalidAccountDSN := fmt.Sprintf("firebolt:///%s?account_name=%s&client_id=%s&client_secret=%s&engine=%s",
         databaseName, "invalid", clientId, clientSecret, engineName)
     db, err = sql.Open("firebolt", invalidAccountDSN)
-	    if err != nil {
+	if err != nil {
         if errors.Is(err, fireboltErrors.InvalidAccountError) {
             log.Println("Invalid account name. Please check your account name and try again")
         } else {

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ package main
 import (
 	"database/sql"
 	"fmt"
+	"log"
+
 	// we need to import firebolt-go-sdk in order to register the driver
 	_ "github.com/firebolt-db/firebolt-go-sdk"
 )
@@ -47,49 +49,50 @@ func main() {
 	clientSecret := ""
 	accountName := ""
 	databaseName := ""
-	dsn := fmt.Sprintf("firebolt:///%s?account_name=%s&client_id=%s&client_secret=%s", databaseName, accountName, clientId, clientSecret)
+	engineName := ""
+	dsn := fmt.Sprintf("firebolt:///%s?account_name=%s&client_id=%s&client_secret=%s&engine=%s", databaseName, accountName, clientId, clientSecret, engineName)
 
 	// open a Firebolt connection
 	db, err := sql.Open("firebolt", dsn)
 	if err != nil {
-		fmt.Printf("error during opening a driver: %v", err)
+		log.Fatalf("error during opening a driver: %v", err)
 	}
 
 	// create a table
 	_, err = db.Query("CREATE TABLE test_table(id INT, value TEXT)")
 	if err != nil {
-		fmt.Printf("error during select query: %v", err)
+		log.Fatalf("error during select query: %v", err)
 	}
 
 	// execute a parametrized insert (only ? placeholders are supported)
 	_, err = db.Query("INSERT INTO test_table VALUES (?, ?)", 1, "my value")
 	if err != nil {
-		fmt.Printf("error during select query: %v", err)
+		log.Fatalf("error during select query: %v", err)
 	}
 
 	// execute a simple select query
 	rows, err := db.Query("SELECT id FROM test_table")
 	if err != nil {
-		fmt.Printf("error during select query: %v", err)
+		log.Fatalf("error during select query: %v", err)
 	}
 
 	// iterate over the result
 	defer func() {
 		if err := rows.Close(); err != nil {
-			fmt.Printf("error during rows.Close(): %v\n", err)
+			log.Printf("error during rows.Close(): %v\n", err)
 		}
 	}()
-	
+
 	for rows.Next() {
 		var id int
 		if err := rows.Scan(&id); err != nil {
-			fmt.Printf("error during scan: %v", err)
+			log.Fatalf("error during scan: %v", err)
 		}
-		fmt.Println(id)
+		log.Print(id)
 	}
 
 	if err := rows.Err(); err != nil {
-		fmt.Printf("error during rows iteration: %v\n", err)
+		log.Fatalf("error during rows iteration: %v\n", err)
 	}
 }
 ```
@@ -104,12 +107,13 @@ Here is an example of how to do it:
 package main
 
 import (
-    "context"
-    "database/sql"
-    "fmt"
-	
-    // we need to import firebolt-go-sdk in order to register the driver
-    _ "github.com/firebolt-db/firebolt-go-sdk"
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+
+	// we need to import firebolt-go-sdk in order to register the driver
+	_ "github.com/firebolt-db/firebolt-go-sdk"
 	fireboltContext "github.com/firebolt-db/firebolt-go-sdk/context"
 )
 
@@ -119,40 +123,41 @@ func main() {
 	clientSecret := ""
 	accountName := ""
 	databaseName := ""
-	dsn := fmt.Sprintf("firebolt:///%s?account_name=%s&client_id=%s&client_secret=%s", databaseName, accountName, clientId, clientSecret)
+	engineName := ""
+	dsn := fmt.Sprintf("firebolt:///%s?account_name=%s&client_id=%s&client_secret=%s&engine=%s", databaseName, accountName, clientId, clientSecret, engineName)
 
 	// open a Firebolt connection
 	db, err := sql.Open("firebolt", dsn)
 	if err != nil {
-		fmt.Printf("error during opening a driver: %v", err)
+		log.Fatalf("error during opening a driver: %v", err)
 	}
-	
+
 	// create a streaming context
 	streamingCtx := fireboltContext.WithStreaming(context.Background())
 
 	// execute a large select query
-	rows, err := db.QueryContext(streamingCtx, "SELECT \"abc\" FROM generate_series(1, 100000000)")
+	rows, err := db.QueryContext(streamingCtx, "SELECT 'abc' FROM generate_series(1, 100000000)")
 	if err != nil {
-		fmt.Printf("error during select query: %v", err)
+		log.Fatalf("error during select query: %v", err)
 	}
 
 	// iterating over the result is exactly the same as in the previous example
 	defer func() {
 		if err := rows.Close(); err != nil {
-			fmt.Printf("error during rows.Close(): %v\n", err)
+			log.Printf("error during rows.Close(): %v\n", err)
 		}
 	}()
 
 	for rows.Next() {
 		var id int
 		if err := rows.Scan(&id); err != nil {
-			fmt.Printf("error during scan: %v", err)
+			log.Fatalf("error during scan: %v", err)
 		}
-		fmt.Println(id)
+		log.Print(id)
 	}
 
 	if err := rows.Err(); err != nil {
-		fmt.Printf("error during rows iteration: %v\n", err)
+		log.Fatalf("error during rows iteration: %v\n", err)
 	}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -202,9 +202,9 @@ func main() {
 	}
 
 	// Example 2: Invalid credentials
-	invalidCredsDSN := fmt.Sprintf("firebolt:///%s?account_name=%s&client_id=%s&client_secret=%s&engine=%s",
+	invalidCredentialsDSN := fmt.Sprintf("firebolt:///%s?account_name=%s&client_id=%s&client_secret=%s&engine=%s",
 		databaseName, accountName, "invalid", "invalid", engineName)
-	db, err = sql.Open("firebolt", invalidCredsDSN)
+	db, err = sql.Open("firebolt", invalidCredentialsDSN)
 	if err != nil {
 		if errors.Is(err, fireboltErrors.AuthenticationError) {
 			log.Println("Authentication error. Please check your credentials and try again")
@@ -212,8 +212,20 @@ func main() {
 			log.Fatalf("Unexpected error type: %v", err)
 		}
 	}
-
-	// Example 3: Invalid SQL query
+	
+	// Example 3: Invalid account name
+    invalidAccountDSN := fmt.Sprintf("firebolt:///%s?account_name=%s&client_id=%s&client_secret=%s&engine=%s",
+        databaseName, "invalid", clientId, clientSecret, engineName)
+    db, err = sql.Open("firebolt", invalidAccountDSN)
+	    if err != nil {
+        if errors.Is(err, fireboltErrors.InvalidAccountError) {
+            log.Println("Invalid account name. Please check your account name and try again")
+        } else {
+            log.Fatalf("Unexpected error type: %v", err)
+        }
+    }
+	
+	// Example 4: Invalid SQL query
 	dsn := fmt.Sprintf("firebolt:///%s?account_name=%s&client_id=%s&client_secret=%s&engine=%s",
 		databaseName, accountName, clientId, clientSecret, engineName)
 	db, err = sql.Open("firebolt", dsn)
@@ -235,11 +247,11 @@ func main() {
 ```
 
 The SDK provides the following error types:
-- `DSNParseError`: When the DSN string format is invalid
-- `AuthenticationError`: When credentials are invalid or authentication fails
-- `QueryExecutionError`: When a SQL query fails to execute
-- `AuthorizationError`: When the user doesn't have permission to perform an action
-- `SystemEngineResolutionError`: When there's an error getting the system engine URL
+- `DSNParseError`: Provided DSN string format is invalid
+- `AuthenticationError`: Authentication failure
+- `QueryExecutionError`: SQL query execution error
+- `AuthorizationError`:A user doesn't have permission to perform an action
+- `InvalidAccountError`: Provided account name is invalid or no permissions to access the account
 
 Each error type can be checked using `errors.Is(err, errorType)`. This allows for specific error handling based on the type of error encountered.
 

--- a/client/auth.go
+++ b/client/auth.go
@@ -58,7 +58,10 @@ func getAccessTokenUsernamePassword(username string, password string, apiEndpoin
 		}
 		logging.Infolog.Printf("Start authentication into '%s' using '%s'", apiEndpoint, loginUrl)
 		resp := DoHttpRequest(requestParameters{context.TODO(), "", "POST", apiEndpoint + loginUrl, userAgent, nil, body, contentType})
-		if resp.err != nil {
+		if resp.statusCode == 400 || resp.statusCode == 403 {
+			return "", errors.Wrap(errors.AuthenticationError, resp.err)
+		} else if resp.err != nil {
+			fmt.Printf("Status code: %d\n", resp.statusCode)
 			return "", errors.ConstructNestedError("authentication request failed", resp.err)
 		}
 
@@ -112,7 +115,9 @@ func getAccessTokenServiceAccount(clientId string, clientSecret string, apiEndpo
 		}
 		logging.Infolog.Printf("Start authentication into '%s' using '%s'", authEndpoint, loginUrl)
 		resp := DoHttpRequest(requestParameters{context.TODO(), "", "POST", authEndpoint + loginUrl, userAgent, nil, body, contentType})
-		if resp.err != nil {
+		if resp.statusCode == 401 {
+			return "", errors.Wrap(errors.AuthenticationError, resp.err)
+		} else if resp.err != nil {
 			return "", errors.ConstructNestedError("authentication request failed", resp.err)
 		}
 

--- a/client/auth.go
+++ b/client/auth.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 	"time"
@@ -58,7 +59,7 @@ func getAccessTokenUsernamePassword(username string, password string, apiEndpoin
 		}
 		logging.Infolog.Printf("Start authentication into '%s' using '%s'", apiEndpoint, loginUrl)
 		resp := DoHttpRequest(requestParameters{context.TODO(), "", "POST", apiEndpoint + loginUrl, userAgent, nil, body, contentType})
-		if resp.statusCode == 400 || resp.statusCode == 403 {
+		if resp.statusCode == http.StatusBadRequest || resp.statusCode == http.StatusForbidden {
 			return "", errors.Wrap(errors.AuthenticationError, resp.err)
 		} else if resp.err != nil {
 			fmt.Printf("Status code: %d\n", resp.statusCode)
@@ -115,7 +116,7 @@ func getAccessTokenServiceAccount(clientId string, clientSecret string, apiEndpo
 		}
 		logging.Infolog.Printf("Start authentication into '%s' using '%s'", authEndpoint, loginUrl)
 		resp := DoHttpRequest(requestParameters{context.TODO(), "", "POST", authEndpoint + loginUrl, userAgent, nil, body, contentType})
-		if resp.statusCode == 401 {
+		if resp.statusCode == http.StatusUnauthorized {
 			return "", errors.Wrap(errors.AuthenticationError, resp.err)
 		} else if resp.err != nil {
 			return "", errors.ConstructNestedError("authentication request failed", resp.err)

--- a/client/auth_common_integration_test.go
+++ b/client/auth_common_integration_test.go
@@ -21,7 +21,7 @@ func TestAuthHappyPath(t *testing.T) {
 
 func testAuthWrongCredential(t *testing.T, newVersion bool) {
 	_, err := ClientFactory(&types.FireboltSettings{
-		ClientID:     "TestAuthWrongCredential",
+		ClientID:     "test_auth_wrong_credential",
 		ClientSecret: "wrong_secret",
 		NewVersion:   newVersion,
 	}, GetHostNameURL())
@@ -35,7 +35,7 @@ func testAuthWrongCredential(t *testing.T, newVersion bool) {
 
 func testAuthEmptyCredential(t *testing.T, newVersion bool) {
 	_, err := ClientFactory(&types.FireboltSettings{
-		ClientID:     "TestAuthEmptyCredential",
+		ClientID:     "test_auth_empty_credential",
 		ClientSecret: "",
 		NewVersion:   newVersion,
 	}, GetHostNameURL())

--- a/client/auth_common_integration_test.go
+++ b/client/auth_common_integration_test.go
@@ -1,0 +1,48 @@
+//go:build integration || integration_v0
+// +build integration integration_v0
+
+package client
+
+import (
+	"errors"
+	"testing"
+
+	errorUtils "github.com/firebolt-db/firebolt-go-sdk/errors"
+
+	"github.com/firebolt-db/firebolt-go-sdk/types"
+)
+
+// TestAuthHappyPath tests normal authentication, and that the access token is actually set
+func TestAuthHappyPath(t *testing.T) {
+	if len(getCachedAccessToken(clientMock.ClientID, clientMock.ApiEndpoint)) == 0 {
+		t.Errorf("Token is not set properly")
+	}
+}
+
+func testAuthWrongCredential(t *testing.T, newVersion bool) {
+	_, err := ClientFactory(&types.FireboltSettings{
+		ClientID:     "TestAuthWrongCredential",
+		ClientSecret: "wrong_secret",
+		NewVersion:   newVersion,
+	}, GetHostNameURL())
+	if err == nil {
+		t.Fatalf("Authentication with wrong secret didn't return an error for newVersion=%v", newVersion)
+	}
+	if !errors.Is(err, errorUtils.AuthenticationError) {
+		t.Fatalf("Expected error to be of type AuthenticationError, got %v", err)
+	}
+}
+
+func testAuthEmptyCredential(t *testing.T, newVersion bool) {
+	_, err := ClientFactory(&types.FireboltSettings{
+		ClientID:     "TestAuthEmptyCredential",
+		ClientSecret: "",
+		NewVersion:   newVersion,
+	}, GetHostNameURL())
+	if err == nil {
+		t.Fatalf("Authentication with empty secret didn't return an error for newVersion=%v", newVersion)
+	}
+	if !errors.Is(err, errorUtils.AuthenticationError) {
+		t.Fatalf("Expected error to be of type AuthenticationError, got %v", err)
+	}
+}

--- a/client/auth_integration_test.go
+++ b/client/auth_integration_test.go
@@ -4,7 +4,11 @@
 package client
 
 import (
+	"errors"
+	"fmt"
 	"testing"
+
+	errorUtils "github.com/firebolt-db/firebolt-go-sdk/errors"
 
 	"github.com/firebolt-db/firebolt-go-sdk/types"
 )
@@ -18,38 +22,38 @@ func TestAuthHappyPath(t *testing.T) {
 
 // TestAuthWrongCredential checks that authentication with wrong credentials returns an error
 func TestAuthWrongCredential(t *testing.T) {
-	if _, err := ClientFactory(&types.FireboltSettings{
-		ClientID:     "TestAuthWrongCredential",
-		ClientSecret: "wrong_secret",
-		NewVersion:   true,
-	}, GetHostNameURL()); err == nil {
-		t.Errorf("Authentication with wrong credentials didn't return an error for service account authentication")
-	}
-
-	if _, err := ClientFactory(&types.FireboltSettings{
-		ClientID:     "TestAuthWrongCredential",
-		ClientSecret: "wrong_password",
-		NewVersion:   false,
-	}, GetHostNameURL()); err == nil {
-		t.Errorf("Authentication with wrong credentials didn't return an error for username/password authentication")
+	for _, newVersion := range []bool{true, false} {
+		t.Run(fmt.Sprintf("newVersion=%v", newVersion), func(t *testing.T) {
+			_, err := ClientFactory(&types.FireboltSettings{
+				ClientID:     "TestAuthWrongCredential",
+				ClientSecret: "wrong_secret",
+				NewVersion:   newVersion,
+			}, GetHostNameURL())
+			if err == nil {
+				t.Fatalf("Authentication with wrong secret didn't return an error for newVersion=%v", newVersion)
+			}
+			if !errors.Is(err, errorUtils.AuthenticationError) {
+				t.Fatalf("Expected error to be of type AuthenticationError, got %v", err)
+			}
+		})
 	}
 }
 
 // TestAuthEmptyCredential checks that authentication with empty password returns an error
 func TestAuthEmptyCredential(t *testing.T) {
-	if _, err := ClientFactory(&types.FireboltSettings{
-		ClientID:     "TestAuthEmptyCredential",
-		ClientSecret: "",
-		NewVersion:   true,
-	}, GetHostNameURL()); err == nil {
-		t.Errorf("Authentication with empty password didn't return an error for service account authentication")
-	}
-
-	if _, err := ClientFactory(&types.FireboltSettings{
-		ClientID:     "TestAuthEmptyCredential",
-		ClientSecret: "",
-		NewVersion:   false,
-	}, GetHostNameURL()); err == nil {
-		t.Errorf("Authentication with empty password didn't return an error for username/password authentication")
+	for _, newVersion := range []bool{true, false} {
+		t.Run(fmt.Sprintf("newVersion=%v", newVersion), func(t *testing.T) {
+			_, err := ClientFactory(&types.FireboltSettings{
+				ClientID:     "TestAuthEmptyCredential",
+				ClientSecret: "",
+				NewVersion:   newVersion,
+			}, GetHostNameURL())
+			if err == nil {
+				t.Fatalf("Authentication with empty secret didn't return an error for newVersion=%v", newVersion)
+			}
+			if !errors.Is(err, errorUtils.AuthenticationError) {
+				t.Fatalf("Expected error to be of type AuthenticationError, got %v", err)
+			}
+		})
 	}
 }

--- a/client/auth_integration_v0_test.go
+++ b/client/auth_integration_v0_test.go
@@ -1,5 +1,5 @@
-//go:build integration
-// +build integration
+//go:build integration_v0
+// +build integration_v0
 
 package client
 
@@ -9,10 +9,10 @@ import (
 
 // TestAuthWrongCredential checks that authentication with wrong credentials returns an error
 func TestAuthWrongCredential(t *testing.T) {
-	testAuthWrongCredential(t, true)
+	testAuthWrongCredential(t, false)
 }
 
 // TestAuthEmptyCredential checks that authentication with empty password returns an error
 func TestAuthEmptyCredential(t *testing.T) {
-	testAuthEmptyCredential(t, true)
+	testAuthEmptyCredential(t, false)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -26,10 +26,6 @@ type ClientImpl struct {
 	BaseClient
 }
 
-const accountError = `account '%s' does not exist in this organization or is not authorized.
-Please verify the account name and make sure your service account has the
-correct RBAC permissions and is linked to a user`
-
 func initialiseCaches() error {
 	var err error
 	if AccountCache == nil {
@@ -102,7 +98,7 @@ func (c *ClientImpl) getSystemEngineURLAndParameters(ctx context.Context, accoun
 
 	resp := c.requestWithAuthRetry(ctx, "GET", url, make(map[string]string), "")
 	if resp.statusCode == 404 {
-		return "", nil, fmt.Errorf(accountError, accountName)
+		return "", nil, errorUtils.InvalidAccountError
 	}
 	if resp.err != nil {
 		return "", nil, errorUtils.ConstructNestedError("error during system engine url http request", resp.err)
@@ -155,7 +151,7 @@ func (c *ClientImpl) GetConnectionParameters(ctx context.Context, engineName, da
 
 	engineURL, parameters, err := c.getSystemEngineURLAndParameters(context.Background(), c.AccountName, databaseName)
 	if err != nil {
-		return "", nil, errorUtils.Wrap(errorUtils.SystemEngineResolutionError, err)
+		return "", nil, errorUtils.ConstructNestedError("error during getting system engine url", err)
 	}
 	c.ConnectedToSystemEngine = true
 

--- a/client/client.go
+++ b/client/client.go
@@ -155,7 +155,7 @@ func (c *ClientImpl) GetConnectionParameters(ctx context.Context, engineName, da
 
 	engineURL, parameters, err := c.getSystemEngineURLAndParameters(context.Background(), c.AccountName, databaseName)
 	if err != nil {
-		return "", nil, errorUtils.ConstructNestedError("error during getting system engine url", err)
+		return "", nil, errorUtils.Wrap(errorUtils.SystemEngineResolutionError, err)
 	}
 	c.ConnectedToSystemEngine = true
 

--- a/client/client_base.go
+++ b/client/client_base.go
@@ -156,6 +156,11 @@ func (c *BaseClient) requestWithAuthRetry(ctx context.Context, method string, ur
 		}
 		// Trying to send the same request again now that the access token has been refreshed
 		resp = DoHttpRequest(requestParameters{ctx, accessToken, method, url, c.UserAgent, params, bodyStr, ContentTypeJSON})
+
+		// If the request still fails, wrap the error with UnauthorizedError
+		if resp.statusCode == http.StatusUnauthorized {
+			resp.err = errorUtils.Wrap(errorUtils.UnauthorizedError, resp.err)
+		}
 	}
 	return resp
 }

--- a/client/client_base.go
+++ b/client/client_base.go
@@ -157,9 +157,9 @@ func (c *BaseClient) requestWithAuthRetry(ctx context.Context, method string, ur
 		// Trying to send the same request again now that the access token has been refreshed
 		resp = DoHttpRequest(requestParameters{ctx, accessToken, method, url, c.UserAgent, params, bodyStr, ContentTypeJSON})
 
-		// If the request still fails, wrap the error with UnauthorizedError
+		// If the request still fails, wrap the error with AuthorizationError
 		if resp.statusCode == http.StatusUnauthorized {
-			resp.err = errorUtils.Wrap(errorUtils.UnauthorizedError, resp.err)
+			resp.err = errorUtils.Wrap(errorUtils.AuthorizationError, resp.err)
 		}
 	}
 	return resp

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -142,7 +142,7 @@ func TestFetchTokenWhenExpired(t *testing.T) {
 	}
 
 	if totalCount != 4 {
-		t.Errorf("Expected to call the server 5 times (2x to fetch tokens and 3x to send the request that returns a 403). Total: %d", totalCount)
+		t.Errorf("Expected to call the server 4 times (2x to fetch tokens and 2x to send the request that returns a 403). Total: %d", totalCount)
 	}
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -221,8 +221,8 @@ func TestGetSystemEngineURLReturnsErrorOn404(t *testing.T) {
 	if err == nil {
 		t.Errorf("Expected an error, got nil")
 	}
-	if !strings.HasPrefix(err.Error(), fmt.Sprintf("account '%s' does not exist", testAccountName)) {
-		t.Errorf("Expected error to start with \"account '%s' does not exist\", got \"%s\"", testAccountName, err.Error())
+	if !strings.HasPrefix(err.Error(), "provided account name does not exist") {
+		t.Errorf("Expected error to start with \"provided account name does not exist\", got \"%s\"", err.Error())
 	}
 }
 

--- a/client/client_v0_test.go
+++ b/client/client_v0_test.go
@@ -138,7 +138,7 @@ func TestFetchTokenWhenExpiredV0(t *testing.T) {
 	}
 
 	if totalCount != 4 {
-		t.Errorf("Expected to call the server 5 times (2x to fetch tokens and 3x to send the request that returns a 403). Total: %d", totalCount)
+		t.Errorf("Expected to call the server 4 times (2x to fetch tokens and 4x to send the request that returns a 403). Total: %d", totalCount)
 	}
 }
 

--- a/client/http_client.go
+++ b/client/http_client.go
@@ -147,16 +147,6 @@ func DoHttpRequest(reqParams requestParameters) *Response {
 		return MakeResponse(nil, 0, nil, errorUtils.ConstructNestedError("error during a request execution", err))
 	}
 
-	/*defer resp.Body.Close()
-	// Error might be in the Response body, despite the status code 200
-	errorResponse := struct {
-		Errors []types.ErrorDetails `json:"errors"`
-	}{}
-	if err = json.Unmarshal(body, &errorResponse); err == nil {
-		if errorResponse.Errors != nil {
-			return Response{nil, resp.StatusCode, nil, errorUtils.NewStructuredError(errorResponse.Errors)}
-		}
-	}*/
 	return MakeResponse(resp.Body, resp.StatusCode, resp.Header, nil)
 }
 

--- a/client/user_agent.go
+++ b/client/user_agent.go
@@ -22,7 +22,7 @@ func ConstructUserAgentString() (ua_string string) {
 		// ConstructUserAgentString is a non-essential function, used for statistic gathering
 		// so carry on working if a failure occurs
 		if err := recover(); err != nil {
-			logging.Infolog.Printf("Unable to generate User Agent string")
+			logging.Infolog.Printf("Unable to generate User Agent string: %v", err)
 			ua_string = "GoSDK"
 		}
 	}()

--- a/connection.go
+++ b/connection.go
@@ -84,7 +84,7 @@ func (c *fireboltConnection) queryContextInternal(ctx context.Context, query str
 			if err != nil {
 				return rowsInst, errorUtils.ConstructNestedError("statement recognized as an invalid set statement", err)
 			} else if err = rowsInst.ProcessAndAppendResponse(client.MakeResponse(nil, 200, nil, nil)); err != nil {
-				return rowsInst, errorUtils.ConstructNestedError("error during query execution", err)
+				return rowsInst, errorUtils.Wrap(errorUtils.QueryExecutionError, err)
 			}
 		} else {
 			if response, err := c.client.Query(ctx, c.engineUrl, query, c.parameters, client.ConnectionControl{
@@ -92,9 +92,9 @@ func (c *fireboltConnection) queryContextInternal(ctx context.Context, query str
 				SetEngineURL:     c.setEngineURL,
 				ResetParameters:  c.resetParameters,
 			}); err != nil {
-				return rowsInst, errorUtils.ConstructNestedError("error during query execution", err)
+				return rowsInst, errorUtils.Wrap(errorUtils.QueryExecutionError, err)
 			} else if err = rowsInst.ProcessAndAppendResponse(response); err != nil {
-				return rowsInst, errorUtils.ConstructNestedError("error during query execution", err)
+				return rowsInst, errorUtils.Wrap(errorUtils.QueryExecutionError, err)
 			}
 		}
 	}

--- a/driver.go
+++ b/driver.go
@@ -45,19 +45,19 @@ func (d *FireboltDriver) OpenConnector(dsn string) (driver.Connector, error) {
 		// parsing dsn string to get configuration settings
 		settings, err := ParseDSNString(dsn)
 		if err != nil {
-			return nil, errors.ConstructNestedError("error during parsing a dsn", err)
+			return nil, errors.Wrap(errors.DSNParseError, err)
 		}
 
 		// authenticating and getting access token
 		logging.Infolog.Println("dsn parsed correctly, trying to authenticate")
 		d.client, err = client.ClientFactory(settings, client.GetHostNameURL())
 		if err != nil {
-			return nil, errors.ConstructNestedError("error during authentication", err)
+			return nil, errors.ConstructNestedError("error during initializing client", err)
 		}
 
 		d.engineUrl, d.cachedParams, err = d.client.GetConnectionParameters(context.TODO(), settings.EngineName, settings.Database)
 		if err != nil {
-			return nil, errors.ConstructNestedError("error during getting engine url", err)
+			return nil, errors.ConstructNestedError("error during getting connection parameters", err)
 		}
 		d.lastUsedDsn = dsn //nolint
 	}

--- a/driver_common_integration_test.go
+++ b/driver_common_integration_test.go
@@ -1,0 +1,38 @@
+//go:build integration || integration_v0
+// +build integration integration_v0
+
+package fireboltgosdk
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+
+	errorUtils "github.com/firebolt-db/firebolt-go-sdk/errors"
+)
+
+func runTestDriverExecStatement(t *testing.T, dsn string) {
+	db, err := sql.Open("firebolt", dsn)
+	if err != nil {
+		t.Errorf("failed unexpectedly")
+	}
+
+	if _, err = db.Exec("SELECT 1"); err != nil {
+		t.Errorf("connection is not established correctly")
+	}
+}
+
+func runTestDriverInvalidAuthError(t *testing.T, dsn string) {
+	db, err := sql.Open("firebolt", dsn)
+	if err == nil {
+		t.Errorf("failed unexpectedly")
+	}
+
+	if !errors.Is(err, errorUtils.AuthenticationError) {
+		t.Errorf("error should be AuthenticationError")
+	}
+
+	if db != nil {
+		t.Errorf("connection should not be established")
+	}
+}

--- a/driver_integration_test.go
+++ b/driver_integration_test.go
@@ -141,17 +141,6 @@ func TestDriverOpenConnection(t *testing.T) {
 	}
 }
 
-func runTestDriverExecStatement(t *testing.T, dsn string) {
-	db, err := sql.Open("firebolt", dsn)
-	if err != nil {
-		t.Errorf("failed unexpectedly: %s", err)
-	}
-
-	if _, err = db.Exec("SELECT 1"); err != nil {
-		t.Errorf("connection is not established correctly: %s", err)
-	}
-}
-
 // TestDriverOpenEngineUrl checks opening connector with a default engine
 func TestDriverOpenNoDatabase(t *testing.T) {
 	runTestDriverExecStatement(t, dsnNoDatabaseMock)
@@ -288,4 +277,9 @@ func TestParametrisedQuery(t *testing.T) {
 	if engineName != engineNameMock || status != "RUNNING" {
 		t.Errorf("Results not equal: %s %s", engineName, status)
 	}
+}
+
+func TestDriverInvalidAuthError(t *testing.T) {
+	dsn := fmt.Sprintf("firebolt:///%s?account_name=%s&engine=%s&client_id=%s&client_secret=%s", databaseMock, accountName, engineNameMock, "invalid", "invalid")
+	runTestDriverInvalidAuthError(t, dsn)
 }

--- a/driver_integration_test.go
+++ b/driver_integration_test.go
@@ -247,7 +247,7 @@ func TestIncorrectQueryThrowingStructuredError(t *testing.T) {
 		t.Errorf("Query didn't return an error, although it should")
 	}
 
-	if !strings.HasPrefix(err.Error(), "error during query execution: error during query request:") || !strings.Contains(err.Error(), "Unable to cast text 'blue' to integer") {
+	if !strings.HasPrefix(err.Error(), "query execution error: error during query request:") || !strings.Contains(err.Error(), "Unable to cast text 'blue' to integer") {
 		t.Errorf("Query didn't return an error with correct message, got: %s", err.Error())
 	}
 }

--- a/driver_integration_v0_test.go
+++ b/driver_integration_v0_test.go
@@ -142,17 +142,6 @@ func TestDriverOpenConnection(t *testing.T) {
 	}
 }
 
-func runTestDriverExecStatement(t *testing.T, dsn string) {
-	db, err := sql.Open("firebolt", dsn)
-	if err != nil {
-		t.Errorf("failed unexpectedly")
-	}
-
-	if _, err = db.Exec("SELECT 1"); err != nil {
-		t.Errorf("connection is not established correctly")
-	}
-}
-
 // TestDriverOpenEngineUrl checks opening connector with a default engine
 func TestDriverOpenEngineUrl(t *testing.T) {
 	runTestDriverExecStatement(t, dsnEngineUrlMock)
@@ -166,4 +155,9 @@ func TestDriverOpenDefaultEngine(t *testing.T) {
 // TestDriverExecStatement checks exec with full dsn
 func TestDriverExecStatement(t *testing.T) {
 	runTestDriverExecStatement(t, dsnMock)
+}
+
+func TestDriverInvalidAuthError(t *testing.T) {
+	dsn := fmt.Sprintf("firebolt://%s:%s@%s/%s?account_name=%s", "invalid", "invalid", databaseMock, engineNameMock, accountNameMock)
+	runTestDriverInvalidAuthError(t, dsn)
 }

--- a/driver_options_integration_test.go
+++ b/driver_options_integration_test.go
@@ -208,7 +208,7 @@ func TestFireboltConnectorWithOptionsInvalidToken(t *testing.T) {
 		t.Errorf("expected to fail with invalid token")
 		t.FailNow()
 	}
-	if !errors.Is(err, errorUtils.UnauthorizedError) {
+	if !errors.Is(err, errorUtils.AuthorizationError) {
 		t.Errorf("expected to fail with unauthorized error, got: %v", err)
 	}
 }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,1 +1,5 @@
 package errors
+
+var (
+	AuthenticationError = ConstructNestedError("authentication error", nil)
+)

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,12 +1,1 @@
 package errors
-
-import (
-	"fmt"
-
-	"github.com/firebolt-db/firebolt-go-sdk/logging"
-)
-
-func ConstructNestedError(message string, err error) error {
-	logging.Infolog.Printf("%s: %v", message, err)
-	return fmt.Errorf("%s: %v", message, err)
-}

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -2,6 +2,7 @@ package errors
 
 var (
 	AuthenticationError         = ConstructNestedError("authentication error", nil)
+	UnauthorizedError           = ConstructNestedError("authorization error", nil)
 	QueryExecutionError         = ConstructNestedError("query execution error", nil)
 	SystemEngineResolutionError = ConstructNestedError("error getting system engine URL", nil)
 	DSNParseError               = ConstructNestedError("error parsing DSN", nil)

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,5 +1,8 @@
 package errors
 
 var (
-	AuthenticationError = ConstructNestedError("authentication error", nil)
+	AuthenticationError         = ConstructNestedError("authentication error", nil)
+	QueryExecutionError         = ConstructNestedError("query execution error", nil)
+	SystemEngineResolutionError = ConstructNestedError("error getting system engine URL", nil)
+	DSNParseError               = ConstructNestedError("error parsing DSN", nil)
 )

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,9 +1,13 @@
 package errors
 
+const accountErrorMsg = `provided account name does not exist in this organization or is not authorized.
+Please verify the account name and make sure your service account has the
+correct RBAC permissions and is linked to a user`
+
 var (
-	AuthenticationError         = ConstructNestedError("authentication error", nil)
-	AuthorizationError          = ConstructNestedError("authorization error", nil)
-	QueryExecutionError         = ConstructNestedError("query execution error", nil)
-	SystemEngineResolutionError = ConstructNestedError("error getting system engine URL", nil)
-	DSNParseError               = ConstructNestedError("error parsing DSN", nil)
+	AuthenticationError = ConstructNestedError("authentication error", nil)
+	AuthorizationError  = ConstructNestedError("authorization error", nil)
+	QueryExecutionError = ConstructNestedError("query execution error", nil)
+	DSNParseError       = ConstructNestedError("error parsing DSN", nil)
+	InvalidAccountError = ConstructNestedError(accountErrorMsg, nil)
 )

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -2,7 +2,7 @@ package errors
 
 var (
 	AuthenticationError         = ConstructNestedError("authentication error", nil)
-	UnauthorizedError           = ConstructNestedError("authorization error", nil)
+	AuthorizationError          = ConstructNestedError("authorization error", nil)
 	QueryExecutionError         = ConstructNestedError("query execution error", nil)
 	SystemEngineResolutionError = ConstructNestedError("error getting system engine URL", nil)
 	DSNParseError               = ConstructNestedError("error parsing DSN", nil)

--- a/errors/nested_error.go
+++ b/errors/nested_error.go
@@ -1,0 +1,38 @@
+package errors
+
+import "github.com/firebolt-db/firebolt-go-sdk/logging"
+
+type nestedError struct {
+	message string
+	err     error
+}
+
+func (e *nestedError) Error() string {
+	if e.err == nil {
+		return e.message
+	}
+	return e.message + ": " + e.err.Error()
+}
+
+func (e *nestedError) Unwrap() error {
+	return e.err
+}
+
+func (e *nestedError) Is(target error) bool {
+	if nErr, ok := target.(*nestedError); ok {
+		return nErr.message == e.message
+	}
+	return e.message == target.Error()
+}
+
+func ConstructNestedError(message string, err error) error {
+	logging.Infolog.Printf("%s: %v", message, err)
+	return &nestedError{message: message, err: err}
+}
+
+func WrapWithError(inner, wrapper error) error {
+	if wrapper == nil {
+		return inner
+	}
+	return ConstructNestedError(wrapper.Error(), inner)
+}

--- a/errors/nested_error.go
+++ b/errors/nested_error.go
@@ -1,7 +1,5 @@
 package errors
 
-import "github.com/firebolt-db/firebolt-go-sdk/logging"
-
 type nestedError struct {
 	message string
 	err     error
@@ -26,7 +24,6 @@ func (e *nestedError) Is(target error) bool {
 }
 
 func ConstructNestedError(message string, err error) error {
-	logging.Infolog.Printf("%s: %v", message, err)
 	return &nestedError{message: message, err: err}
 }
 

--- a/errors/nested_error.go
+++ b/errors/nested_error.go
@@ -30,7 +30,7 @@ func ConstructNestedError(message string, err error) error {
 	return &nestedError{message: message, err: err}
 }
 
-func WrapWithError(inner, wrapper error) error {
+func Wrap(wrapper, inner error) error {
 	if wrapper == nil {
 		return inner
 	}

--- a/errors/nested_error_test.go
+++ b/errors/nested_error_test.go
@@ -23,7 +23,7 @@ func TestNestedErrorIs(t *testing.T) {
 	originalErr := errors.New("original error")
 	mediumErr := errors.New("medium error")
 	topError := errors.New("top error")
-	nestedErr := WrapWithError(WrapWithError(originalErr, mediumErr), topError)
+	nestedErr := Wrap(topError, Wrap(mediumErr, originalErr))
 
 	utils.AssertEqual(errors.Is(nestedErr, topError), true, t, "Top error should be found")
 	utils.AssertEqual(errors.Is(nestedErr, mediumErr), true, t, "Medium error should be found")

--- a/errors/nested_error_test.go
+++ b/errors/nested_error_test.go
@@ -1,0 +1,33 @@
+package errors
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/firebolt-db/firebolt-go-sdk/utils"
+)
+
+func TestNestedErrorError(t *testing.T) {
+	originalErr := errors.New("original error")
+	nestedErr := ConstructNestedError("nested error", originalErr)
+	utils.AssertEqual(nestedErr.Error(), "nested error: original error", t, "Error message should be nested")
+
+	nestedErr2 := ConstructNestedError("nested error", nestedErr)
+	utils.AssertEqual(nestedErr2.Error(), "nested error: nested error: original error", t, "Error message should be doubly nested")
+
+	nestedErr = ConstructNestedError("nested error", nil)
+	utils.AssertEqual(nestedErr.Error(), "nested error", t, "Error message should be nested")
+}
+
+func TestNestedErrorIs(t *testing.T) {
+	originalErr := errors.New("original error")
+	mediumErr := errors.New("medium error")
+	topError := errors.New("top error")
+	nestedErr := WrapWithError(WrapWithError(originalErr, mediumErr), topError)
+
+	utils.AssertEqual(errors.Is(nestedErr, topError), true, t, "Top error should be found")
+	utils.AssertEqual(errors.Is(nestedErr, mediumErr), true, t, "Medium error should be found")
+	utils.AssertEqual(errors.Is(nestedErr, originalErr), true, t, "Original error should be found")
+
+	utils.AssertEqual(errors.Is(nestedErr, errors.New("not found")), false, t, "Non-existent error should not be found")
+}


### PR DESCRIPTION
Added typed errors to distinguish between issues
- AuthenticationError - when 401/403/400 returned for an authentication request
- QueryExecutionError - generic error for when query execution has failed
- SystemEngineResolutionError - failed to get the system engine for an account
- DSNParsingError - failed to parse DSN