### PR TITLE
fix(NoTicket): fix compatibility with 1.16

### DIFF
--- a/data_types_common_integration_test.go
+++ b/data_types_common_integration_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 // runSetupAndSelect runs the setup query and the query and returns the values and column types
-func runSetupAndSelect(t *testing.T, ctx context.Context, setupQueries []string, query, cleanupQuery string) (any, any, any, []*sql.ColumnType, func()) {
+func runSetupAndSelect(t *testing.T, ctx context.Context, setupQueries []string, query, cleanupQuery string) (interface{}, interface{}, interface{}, []*sql.ColumnType, func()) {
 	conn, err := sql.Open("firebolt", dsnMock)
 	if err != nil {
 		t.Errorf(OPEN_CONNECTION_ERROR_MSG)

--- a/rows/column_reader_test.go
+++ b/rows/column_reader_test.go
@@ -2,7 +2,6 @@ package rows
 
 import (
 	"database/sql"
-	"math"
 	"reflect"
 	"testing"
 	"time"
@@ -108,7 +107,7 @@ var testCases = []columnReaderTestCase{
 		expectedType:       reflect.TypeOf(""),
 		expectedDBTypeName: "text",
 		expectedNullable:   false,
-		expectedLength:     math.MaxInt,
+		expectedLength:     int64(^uint(0) >> 1), // math.MaxInt
 		expectedPrecision:  -1,
 		expectedScale:      -1,
 	},
@@ -158,7 +157,7 @@ var testCases = []columnReaderTestCase{
 		expectedType:       reflect.TypeOf(FireboltArray{}),
 		expectedDBTypeName: "array(int)",
 		expectedNullable:   false,
-		expectedLength:     math.MaxInt,
+		expectedLength:     int64(^uint(0) >> 1), // math.MaxInt
 		expectedPrecision:  -1,
 		expectedScale:      -1,
 	},
@@ -188,7 +187,7 @@ var testCases = []columnReaderTestCase{
 		expectedType:       reflect.TypeOf([]byte{}),
 		expectedDBTypeName: "bytea",
 		expectedNullable:   false,
-		expectedLength:     math.MaxInt,
+		expectedLength:     int64(^uint(0) >> 1), // math.MaxInt
 		expectedPrecision:  -1,
 		expectedScale:      -1,
 	},

--- a/rows/firebolt_array.go
+++ b/rows/firebolt_array.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 )
 
-type FireboltArray []any
+type FireboltArray []interface{}
 
 // Scan implements the sql.Scanner interface.
 func (fa *FireboltArray) Scan(src interface{}) error {
@@ -17,7 +17,7 @@ func (fa *FireboltArray) Scan(src interface{}) error {
 		return fmt.Errorf("unexpected array value type: %T", src)
 	}
 
-	*fa = make([]any, t.Len())
+	*fa = make([]interface{}, t.Len())
 	for i := 0; i < t.Len(); i++ {
 		(*fa)[i] = t.Index(i).Interface()
 	}

--- a/rows/firebolt_struct.go
+++ b/rows/firebolt_struct.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 )
 
-type FireboltStruct map[string]any
+type FireboltStruct map[string]interface{}
 
 func (fs *FireboltStruct) Scan(src interface{}) error {
 	if src == nil {
@@ -16,7 +16,7 @@ func (fs *FireboltStruct) Scan(src interface{}) error {
 		return fmt.Errorf("unexpected struct value type: %T", src)
 	}
 
-	*fs = make(map[string]any, t.Len())
+	*fs = make(map[string]interface{}, t.Len())
 	for _, key := range t.MapKeys() {
 		(*fs)[key.String()] = t.MapIndex(key).Interface()
 	}

--- a/utils/test_utils.go
+++ b/utils/test_utils.go
@@ -42,7 +42,7 @@ func AssertEqual(testVal interface{}, expectedVal interface{}, t *testing.T, err
 	}
 }
 
-func assertArrays(testVal any, expectedVal any, t *testing.T, err string) {
+func assertArrays(testVal interface{}, expectedVal interface{}, t *testing.T, err string) {
 	// manually
 	testValType := reflect.ValueOf(testVal)
 	expectedValType := reflect.ValueOf(expectedVal)


### PR DESCRIPTION
`any` and `math.MaxInt` are not compatible with Go versions before 1.18 so changing it to a compatible syntax, since we want to be compatible with 1.16 and up.
Spotted this issue in nightly.