### PR TITLE
feat: FIR-45303 go sdk extend driver options api

### DIFF
--- a/client/client_integration_v0_test.go
+++ b/client/client_integration_v0_test.go
@@ -46,7 +46,7 @@ func init() {
 func TestGetAccountId(t *testing.T) {
 	accountId, err := clientMock.getAccountIDByName(context.TODO(), accountNameMock)
 	if err != nil {
-		t.Errorf("getAccountID failed with: %s", err)
+		t.Errorf("GetAccountID failed with: %s", err)
 	}
 	if len(accountId) == 0 {
 		t.Errorf("returned empty accountId")
@@ -54,7 +54,7 @@ func TestGetAccountId(t *testing.T) {
 
 	_, err = clientMock.getAccountIDByName(context.TODO(), "firebolt_not_existing_account")
 	if err == nil {
-		t.Errorf("getAccountID didn't failed with not-existing account")
+		t.Errorf("GetAccountID didn't failed with not-existing account")
 	}
 }
 
@@ -62,7 +62,7 @@ func TestGetAccountId(t *testing.T) {
 func TestGetEnginePropsByName(t *testing.T) {
 	accountId, err := clientMock.getAccountIDByName(context.TODO(), "firebolt")
 	if err != nil {
-		t.Errorf("getAccountID failed with: %s", err)
+		t.Errorf("GetAccountID failed with: %s", err)
 	}
 
 	engineId, err := clientMock.getEngineIdByName(context.TODO(), engineNameMock, accountId)

--- a/client/client_v0.go
+++ b/client/client_v0.go
@@ -31,7 +31,7 @@ func MakeClientV0(settings *types.FireboltSettings, apiEndpoint string) (*Client
 	client.AccessTokenGetter = client.getAccessToken
 
 	var err error
-	client.AccountID, err = client.getAccountID(context.Background(), settings.AccountName)
+	client.AccountID, err = client.GetAccountID(context.Background(), settings.AccountName)
 	if err != nil {
 		return nil, errorUtils.ConstructNestedError("error during getting account id", err)
 	}
@@ -93,7 +93,7 @@ func (c *ClientImplV0) getDefaultAccountID(ctx context.Context) (string, error) 
 	return defaultAccountResponse.Account.Id, nil
 }
 
-func (c *ClientImplV0) getAccountID(ctx context.Context, accountName string) (string, error) {
+func (c *ClientImplV0) GetAccountID(ctx context.Context, accountName string) (string, error) {
 	var accountId string
 	var err error
 	if accountName == "" {

--- a/driver_options.go
+++ b/driver_options.go
@@ -2,11 +2,20 @@ package fireboltgosdk
 
 import (
 	"context"
+	"errors"
 
 	"github.com/firebolt-db/firebolt-go-sdk/client"
 )
 
 type driverOption func(d *FireboltDriver)
+type driverOptionWithError func(d *FireboltDriver) error
+
+func NoError(option driverOption) driverOptionWithError {
+	return func(d *FireboltDriver) error {
+		option(d)
+		return nil
+	}
+}
 
 // WithEngineUrl defines engine url for the driver
 func WithEngineUrl(engineUrl string) driverOption {
@@ -48,7 +57,9 @@ func withClientOption(setter func(baseClient *client.BaseClient)) driverOption {
 		} else {
 			cl := &client.ClientImpl{
 				ConnectedToSystemEngine: true,
-				BaseClient:              client.BaseClient{},
+				BaseClient: client.BaseClient{
+					ApiEndpoint: client.GetHostNameURL(),
+				},
 			}
 			cl.ParameterGetter = cl.GetQueryParams
 			setter(&cl.BaseClient)
@@ -83,8 +94,8 @@ func WithClientParams(accountID string, token string, userAgent string) driverOp
 }
 
 // WithAccountName defines account name for the driver
-func WithAccountName(accountName string) driverOption {
-	return func(d *FireboltDriver) {
+func WithAccountName(accountName string) driverOptionWithError {
+	return func(d *FireboltDriver) error {
 		if d.client != nil {
 			if clientImpl, ok := d.client.(*client.ClientImpl); ok {
 				clientImpl.AccountName = accountName
@@ -92,36 +103,40 @@ func WithAccountName(accountName string) driverOption {
 				var err error
 				clientImplV0.AccountID, err = clientImplV0.GetAccountID(context.TODO(), accountName)
 				if err != nil {
-					panic(err)
+					return err
 				}
 			}
 		} else {
 			cl := &client.ClientImpl{
 				ConnectedToSystemEngine: true,
-				BaseClient:              client.BaseClient{},
-				AccountName:             accountName,
+				BaseClient: client.BaseClient{
+					ApiEndpoint: client.GetHostNameURL(),
+				},
+				AccountName: accountName,
 			}
 			cl.ParameterGetter = cl.GetQueryParams
 			d.client = cl
 		}
+		return nil
 	}
 }
 
 // WithDatabaseAndEngineName defines database name and engine name for the driver
-func WithDatabaseAndEngineName(databaseName, engineName string) driverOption {
-	return func(d *FireboltDriver) {
+func WithDatabaseAndEngineName(databaseName, engineName string) driverOptionWithError {
+	return func(d *FireboltDriver) error {
 		if d.client == nil {
-			panic("client must be initialized before setting database and engine name")
+			return errors.New("client must be initialized before setting database and engine name")
 		}
 		oldCachedParameters := d.cachedParams
 		var err error
 		d.engineUrl, d.cachedParams, err = d.client.GetConnectionParameters(context.TODO(), engineName, databaseName)
 		if err != nil {
-			panic(err)
+			return err
 		}
 		for key, value := range oldCachedParameters {
 			d.cachedParams[key] = value
 		}
+		return nil
 	}
 }
 
@@ -139,4 +154,22 @@ func FireboltConnectorWithOptions(opts ...driverOption) *FireboltConnector {
 		d.cachedParams,
 		d,
 	}
+}
+
+// FireboltConnectorWithOptionsWithErrors builds a custom connector with error handling
+func FireboltConnectorWithOptionsWithErrors(opts ...driverOptionWithError) (*FireboltConnector, error) {
+	d := &FireboltDriver{}
+
+	for _, opt := range opts {
+		if err := opt(d); err != nil {
+			return nil, err
+		}
+	}
+
+	return &FireboltConnector{
+		d.engineUrl,
+		d.client,
+		d.cachedParams,
+		d,
+	}, nil
 }

--- a/driver_options.go
+++ b/driver_options.go
@@ -51,9 +51,8 @@ func withClientOption(setter func(baseClient *client.BaseClient)) driverOption {
 		if d.client != nil {
 			if clientImpl, ok := d.client.(*client.ClientImpl); ok {
 				setter(&clientImpl.BaseClient)
-			} else if clientImplV0, ok := d.client.(*client.ClientImplV0); ok {
-				setter(&clientImplV0.BaseClient)
 			}
+			// ignore V0 client since it's not supported
 		} else {
 			cl := &client.ClientImpl{
 				ConnectedToSystemEngine: true,
@@ -99,13 +98,8 @@ func WithAccountName(accountName string) driverOptionWithError {
 		if d.client != nil {
 			if clientImpl, ok := d.client.(*client.ClientImpl); ok {
 				clientImpl.AccountName = accountName
-			} else if clientImplV0, ok := d.client.(*client.ClientImplV0); ok {
-				var err error
-				clientImplV0.AccountID, err = clientImplV0.GetAccountID(context.TODO(), accountName)
-				if err != nil {
-					return err
-				}
 			}
+			// ignore V0 client since it's not supported
 		} else {
 			cl := &client.ClientImpl{
 				ConnectedToSystemEngine: true,

--- a/driver_options.go
+++ b/driver_options.go
@@ -127,14 +127,10 @@ func WithDatabaseAndEngineName(databaseName, engineName string) driverOptionWith
 		if d.client == nil {
 			return errors.New("client must be initialized before setting database and engine name")
 		}
-		oldCachedParameters := d.cachedParams
 		var err error
 		d.engineUrl, d.cachedParams, err = d.client.GetConnectionParameters(context.TODO(), engineName, databaseName)
 		if err != nil {
 			return err
-		}
-		for key, value := range oldCachedParameters {
-			d.cachedParams[key] = value
 		}
 		return nil
 	}


### PR DESCRIPTION
Added new options for custom driver configuration
- WithAccountName
- WithDatabaseAndEngineName

Also options can return errors now, and those options should be used with `FireboltConnectorWithOptionsWithErrors `