### PR TITLE
fix: FIR-45327 go sdk streaming failes on empty query

### DIFF
--- a/connection_common_integration_test.go
+++ b/connection_common_integration_test.go
@@ -483,14 +483,19 @@ func TestConnectionEmptyQuery(t *testing.T) {
 			t.FailNow()
 		}
 
-		rows, err := conn.QueryContext(ctx, "")
-		if err != nil {
-			t.Errorf(STATEMENT_ERROR_MSG, err)
+		for _, query := range []string{"", ";", " ; ", ";;", " ; ; "} {
+			t.Run(query, func(t *testing.T) {
+				rows, err := conn.QueryContext(ctx, query)
+				if err != nil {
+					t.Errorf(STATEMENT_ERROR_MSG, err)
+				}
+
+				utils.AssertEqual(rows.Next(), false, t, NEXT_STATEMENT_ERROR_MSG)
+				utils.AssertEqual(rows.Err(), nil, t, "rows.Err() returned an error, but shouldn't")
+				utils.AssertEqual(rows.NextResultSet(), false, t, "NextResultSet() returned true, but shouldn't")
+			})
 		}
 
-		utils.AssertEqual(rows.Next(), false, t, NEXT_STATEMENT_ERROR_MSG)
-		utils.AssertEqual(rows.Err(), nil, t, "rows.Err() returned an error, but shouldn't")
-		utils.AssertEqual(rows.NextResultSet(), false, t, "NextResultSet() returned true, but shouldn't")
 	})
 }
 

--- a/connection_common_integration_test.go
+++ b/connection_common_integration_test.go
@@ -495,7 +495,25 @@ func TestConnectionEmptyQuery(t *testing.T) {
 				utils.AssertEqual(rows.NextResultSet(), false, t, "NextResultSet() returned true, but shouldn't")
 			})
 		}
+	})
+}
 
+func TestConnectionQueryWithEmptyPart(t *testing.T) {
+	utils.RunInMemoryAndStream(t, func(t *testing.T, ctx context.Context) {
+		conn, err := sql.Open("firebolt", dsnMock)
+		if err != nil {
+			t.Errorf(OPEN_CONNECTION_ERROR_MSG)
+			t.FailNow()
+		}
+
+		rows, err := conn.QueryContext(ctx, ";;; select 1 ;;;")
+		if err != nil {
+			t.Errorf(STATEMENT_ERROR_MSG, err)
+		}
+
+		utils.AssertEqual(rows.Next(), true, t, NEXT_STATEMENT_ERROR_MSG)
+		utils.AssertEqual(rows.Err(), nil, t, "rows.Err() returned an error, but shouldn't")
+		utils.AssertEqual(rows.NextResultSet(), false, t, "NextResultSet() returned true, but shouldn't")
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,7 @@ require github.com/matishsiao/goInfo v0.0.0-20210923090445-da2e3fa8d45f
 
 require github.com/astaxie/beego v1.12.3
 
-require github.com/shopspring/decimal v1.4.0
+require (
+	github.com/lib/pq v1.0.0
+	github.com/shopspring/decimal v1.4.0
+)

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,7 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/ledisdb/ledisdb v0.0.0-20200510135210-d35789ec47e6/go.mod h1:n931TsDuKuq+uX4v1fulaMbA/7ZLLhjc85h7chZGBCQ=
+github.com/lib/pq v1.0.0 h1:X5PMW56eZitiTeO7tKzZxFCSpbFZJtkMMooicw2us9A=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/matishsiao/goInfo v0.0.0-20210923090445-da2e3fa8d45f h1:B0OD7nYl2FPQEVrw8g2uyc1lGEzNbvrKh7fspGZcbvY=
 github.com/matishsiao/goInfo v0.0.0-20210923090445-da2e3fa8d45f/go.mod h1:aEt7p9Rvh67BYApmZwNDPpgircTO2kgdmDUoF/1QmwA=

--- a/utils.go
+++ b/utils.go
@@ -100,10 +100,6 @@ func prepareStatement(query string, params []driver.NamedValue) (string, error) 
 func SplitStatements(sql string) ([]string, error) {
 	var queries []string
 
-	if sql == "" {
-		return []string{""}, nil
-	}
-
 	for sql != "" {
 		var err error
 		var query string
@@ -116,6 +112,12 @@ func SplitStatements(sql string) ([]string, error) {
 			continue
 		}
 		queries = append(queries, query)
+	}
+
+	if len(queries) == 0 {
+		// Parser stripped all the symbols and found no meaningfully query
+		// Consider it as empty query
+		return []string{""}, nil
 	}
 
 	return queries, nil


### PR DESCRIPTION
Extended our parser to consider strings like `";"`, `" ; "`, `";;;"` as empty queries (rather than no query at all). Confirmed the exact same behavior with postgres go client.