### PR TITLE
ci(NoTicket): Update go versions

### DIFF
--- a/.github/workflows/integration-test-core.yml
+++ b/.github/workflows/integration-test-core.yml
@@ -26,7 +26,7 @@ on:
 env:
   DEFAULT_IMAGE_TAG: ${{ vars.DEFAULT_CORE_IMAGE_TAG }}
 jobs:
-  resolve-go-version:
+  find-latest-go-version:
     runs-on: ubuntu-latest
     outputs:
       latest_go: ${{ steps.get-go-version.outputs.latest_go }}
@@ -37,7 +37,7 @@ jobs:
           latest_go=${latest_version#go}
           echo "::set-output name=latest_go::$latest_go"
   integration-tests:
-    needs: resolve-go-version
+    needs: find-latest-go-version
     runs-on: ${{ inputs.os_name }}
     env:
       DOCKER_COMPOSE_FILE: ${{ github.workspace }}/.github/workflows/core/docker-compose.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ needs.resolve-go-version.outputs.latest_go }}
+          go-version: ${{ needs.find-latest-go-version.outputs.latest_go }}
           check-latest: true
 
       - name: Log in to GitHub Container Registry

--- a/.github/workflows/integration-test-core.yml
+++ b/.github/workflows/integration-test-core.yml
@@ -26,7 +26,18 @@ on:
 env:
   DEFAULT_IMAGE_TAG: ${{ vars.DEFAULT_CORE_IMAGE_TAG }}
 jobs:
+  resolve-go-version:
+    runs-on: ubuntu-latest
+    outputs:
+      latest_go: ${{ steps.get-go-version.outputs.latest_go }}
+    steps:
+      - id: get-go-version
+        run: |
+          latest_version=$(curl -s https://go.dev/dl/?mode=json | jq -r '.[] | select(.stable == true) | .version' | head -n1)
+          latest_go=${latest_version#go}
+          echo "::set-output name=latest_go::$latest_go"
   integration-tests:
+    needs: resolve-go-version
     runs-on: ${{ inputs.os_name }}
     env:
       DOCKER_COMPOSE_FILE: ${{ github.workspace }}/.github/workflows/core/docker-compose.yaml
@@ -39,9 +50,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.19.0'
+          go-version: ${{ needs.resolve-go-version.outputs.latest_go }}
+          check-latest: true
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/integration-tests-v2.yml
+++ b/.github/workflows/integration-tests-v2.yml
@@ -10,7 +10,7 @@ on:
         required: false
 
 jobs:
-  resolve-go-version:
+  find-latest-go-version:
     runs-on: ubuntu-latest
     outputs:
       latest_go: ${{ steps.get-go-version.outputs.latest_go }}
@@ -22,7 +22,7 @@ jobs:
           echo "::set-output name=latest_go::$latest_go"
 
   integration-tests:
-    needs: resolve-go-version
+    needs: find-latest-go-version
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ needs.resolve-go-version.outputs.latest_go }}
+          go-version: ${{ needs.find-latest-go-version.outputs.latest_go }}
           check-latest: true
 
       - name: Setup database and engine

--- a/.github/workflows/integration-tests-v2.yml
+++ b/.github/workflows/integration-tests-v2.yml
@@ -10,15 +10,28 @@ on:
         required: false
 
 jobs:
+  resolve-go-version:
+    runs-on: ubuntu-latest
+    outputs:
+      latest_go: ${{ steps.get-go-version.outputs.latest_go }}
+    steps:
+      - id: get-go-version
+        run: |
+          latest_version=$(curl -s https://go.dev/dl/?mode=json | jq -r '.[] | select(.stable == true) | .version' | head -n1)
+          latest_go=${latest_version#go}
+          echo "::set-output name=latest_go::$latest_go"
+
   integration-tests:
+    needs: resolve-go-version
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.19.0'
+          go-version: ${{ needs.resolve-go-version.outputs.latest_go }}
+          check-latest: true
 
       - name: Setup database and engine
         id: setup

--- a/.github/workflows/nightly-v2.yml
+++ b/.github/workflows/nightly-v2.yml
@@ -4,24 +4,41 @@ on:
   schedule:
     - cron: '0 2 * * *' # 2 am UTC every day
 jobs:
+  resolve-go-versions:
+    name: Resolve latest Go versions (3 minors)
+    runs-on: ubuntu-latest
+    outputs:
+      go_matrix: ${{ steps.compute.outputs.go_matrix }}
+    steps:
+      - name: Get non-deprecated stable versions of GO
+        id: compute
+        shell: bash
+        run: |
+          set -euo pipefail
+          json=$(curl -s https://go.dev/dl/?mode=json)
+          # Take latest three stable releases as listed by Go (already ordered newest first)
+          matrix=$(echo "$json" | jq -c '[.[] | select(.stable==true) | .version][0:3] | map(sub("^go";"") | sub("\\.[0-9]+$";""))')
+          echo "go_matrix=$matrix" >> "$GITHUB_OUTPUT"
   code-check:
     uses: ./.github/workflows/code-check.yml
   tests:
+    needs: resolve-go-versions
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false # finish all jobs even if one fails
       max-parallel: 2
       matrix:
         os: ['macos-13', 'windows-latest', 'ubuntu-latest']
-        go-version: ['1.16', '1.17', '1.18', '1.19']
+        go-version: ${{ fromJSON(needs.resolve-go-versions.outputs.go_matrix) }}
     steps:
       - name: Check out code
         uses: actions/checkout@v2
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
+          check-latest: true
 
       - name: Install go tools
         run: go get golang.org/x/tools/cmd/cover

--- a/.github/workflows/nightly-v2.yml
+++ b/.github/workflows/nightly-v2.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 2 * * *' # 2 am UTC every day
 jobs:
-  resolve-go-versions:
+  find-latest-go-versions:
     name: Resolve latest Go versions (3 minors)
     runs-on: ubuntu-latest
     outputs:
@@ -22,14 +22,14 @@ jobs:
   code-check:
     uses: ./.github/workflows/code-check.yml
   tests:
-    needs: resolve-go-versions
+    needs: find-latest-go-versions
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false # finish all jobs even if one fails
       max-parallel: 2
       matrix:
         os: ['macos-13', 'windows-latest', 'ubuntu-latest']
-        go-version: ${{ fromJSON(needs.resolve-go-versions.outputs.go_matrix) }}
+        go-version: ${{ fromJSON(needs.find-latest-go-versions.outputs.go_matrix) }}
     steps:
       - name: Check out code
         uses: actions/checkout@v2


### PR DESCRIPTION
- Updated nightly jobs to dynamically determine the stable go versions that are non-deprecated and use them for testing. No need to test on sunsetted version
- Use the latest go version on integration tests for cloud and core 
This API is used to determine go versions - https://go.dev/dl/?mode=json