### PR TITLE
feat: support discovery-based Firebolt connections

### DIFF
--- a/.github/workflows/integration-test-discovery.yml
+++ b/.github/workflows/integration-test-discovery.yml
@@ -1,0 +1,28 @@
+name: Discovery integration tests
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  integration-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "stable"
+          check-latest: true
+
+      - name: Install Firebolt
+        run: bash <(curl -s https://get.firebolt.io/)
+
+      - name: Run discovery integration tests
+        run: go test ./... -timeout=30m -v --tags=integration_discovery
+
+      - name: Stop Firebolt
+        if: always()
+        run: docker rm -f firebolt || true

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -42,3 +42,6 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       FIREBOLT_CORE_DEV_CERT_PRIVATE_KEY: ${{ secrets.FIREBOLT_CORE_DEV_CERT_PRIVATE_KEY }}
       FIREBOLT_CORE_DEV_CERT: ${{ secrets.FIREBOLT_CORE_DEV_CERT }}
+
+  integration-tests-discovery:
+    uses: ./.github/workflows/integration-test-discovery.yml

--- a/README.md
+++ b/README.md
@@ -37,6 +37,22 @@ firebolt://[/database]?url=core_instance_url[&client_side_lb=false]
 - **client_side_lb** - (optional, default `true`) enables client-side round-robin load balancing. The SDK resolves the hostname in **url** to its underlying IP addresses and distributes requests across them. This prevents Go's default connection pooling from pinning all requests to a single pod when **url** points to a Kubernetes service. Set to `false` to disable.
 - **client_side_lb_dns_ttl** - (optional, default `30s`) how often the round-robin resolver re-resolves the hostname to discover new or removed nodes. Accepts any Go duration string (e.g. `5s`, `500ms`, `2m`). Lower values give faster failover; higher values reduce DNS traffic. Only takes effect when `client_side_lb` is enabled.
 
+#### Discovery-based instance
+For new Firebolt deployments that expose `/.well-known/firebolt`, use a host-based DSN:
+```
+firebolt://host[:port]?database=database_name[&engine=engine_name][&ssl_mode=none]
+```
+
+- **database** - (optional) the name of the database to connect to.
+- **engine** - (optional) the engine name to pass as an initial connection parameter.
+- **ssl_mode** - (optional, default `strict`) controls transport security. `strict` uses HTTPS with certificate validation. `none` uses HTTP for host-based discovery DSNs and disables certificate verification for HTTPS endpoints.
+- Any additional query parameters are sent as initial Firebolt connection/session parameters.
+
+For a local Firebolt installed with `bash <(curl -s https://get.firebolt.io/)`:
+```
+firebolt://localhost:3473?database=mydb&ssl_mode=none
+```
+
 ### Custom HTTP transport
 
 The SDK ships with sensible HTTP transport defaults (30s dial timeout, 10s TLS handshake timeout, 30s keep-alive, 90s idle connection timeout). If you need to tune these -- for example, to increase the dial timeout for high-latency networks or the idle connection timeout for long-lived batch pipelines -- use `OpenConnectorWithDSN` together with `WithTransport`:

--- a/client/client_core.go
+++ b/client/client_core.go
@@ -16,7 +16,8 @@ type ClientImplCore struct {
 }
 
 func MakeClientCore(settings *types.FireboltSettings) (*ClientImplCore, error) {
-	httpClient := NewHttpClientWithTransport(settings.Transport)
+	insecureSkipVerify := settings.SSLMode == "none"
+	httpClient := NewHttpClientWithTransportAndTLS(settings.Transport, insecureSkipVerify)
 	var resolver *RoundRobinResolver
 
 	if settings.ClientSideLB {
@@ -33,7 +34,7 @@ func MakeClientCore(settings *types.FireboltSettings) (*ClientImplCore, error) {
 		// to a raw IP address.
 		canonical := MakeCanonicalUrl(settings.Url)
 		if parsed, err := url.Parse(canonical); err == nil && parsed.Scheme == "https" {
-			httpClient = NewHttpClientForLBWithTransport(settings.Transport, parsed.Hostname())
+			httpClient = NewHttpClientForLBWithTransportAndTLS(settings.Transport, parsed.Hostname(), insecureSkipVerify)
 		}
 		logging.Infolog.Printf("client-side load balancing enabled for %s (DNS TTL: %s)", settings.Url, resolver.TTL)
 	}

--- a/client/client_discovery.go
+++ b/client/client_discovery.go
@@ -1,0 +1,186 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	contextUtils "github.com/firebolt-db/firebolt-go-sdk/context"
+	errorUtils "github.com/firebolt-db/firebolt-go-sdk/errors"
+	"github.com/firebolt-db/firebolt-go-sdk/types"
+)
+
+const discoveryPath = "/.well-known/firebolt"
+
+type ClientImplDiscovery struct {
+	BaseClient
+	ConnectionParameters map[string]string
+}
+
+type discoveryResponse struct {
+	EngineURL       string            `json:"engine_url"`
+	EngineUrl       string            `json:"engineUrl"`
+	Endpoint        string            `json:"endpoint"`
+	QueryEndpoint   string            `json:"query_endpoint"`
+	QueryEndpointJS string            `json:"queryEndpoint"`
+	SQLURL          string            `json:"sql_url"`
+	SQLUrl          string            `json:"sqlUrl"`
+	SQLHTTPURL      string            `json:"sql_http_url"`
+	Parameters      map[string]string `json:"parameters"`
+	QueryParameters map[string]string `json:"query_parameters"`
+}
+
+func MakeClientDiscovery(settings *types.FireboltSettings) (*ClientImplDiscovery, error) {
+	httpClient := NewHttpClientWithTransportAndTLS(settings.Transport, settings.SSLMode == "none")
+	client := &ClientImplDiscovery{
+		BaseClient: BaseClient{
+			ApiEndpoint: settings.DiscoveryEndpoint,
+			UserAgent:   ConstructUserAgentString(),
+			HttpClient:  httpClient,
+		},
+		ConnectionParameters: copyStringMap(settings.ConnectionParameters),
+	}
+	client.ParameterGetter = client.GetQueryParams
+	client.AccessTokenGetter = client.getAccessToken
+
+	return client, nil
+}
+
+func (c *ClientImplDiscovery) getOutputFormat(ctx context.Context) string {
+	if contextUtils.IsStreaming(ctx) {
+		return jsonLinesOutputFormat
+	}
+	return jsonOutputFormat
+}
+
+func (c *ClientImplDiscovery) GetQueryParams(ctx context.Context, setStatements map[string]string) (map[string]string, error) {
+	params := map[string]string{"output_format": c.getOutputFormat(ctx)}
+	if contextUtils.IsAsync(ctx) {
+		return nil, errorUtils.AsyncNotSupportedError
+	}
+	for setKey, setValue := range setStatements {
+		params[setKey] = setValue
+	}
+	return params, nil
+}
+
+func (c *ClientImplDiscovery) getAccessToken() (string, error) {
+	return "", nil
+}
+
+func (c *ClientImplDiscovery) GetConnectionParameters(ctx context.Context, engineName, databaseName string) (string, map[string]string, error) {
+	discovery, err := c.getDiscovery(ctx)
+	if err != nil {
+		return "", nil, err
+	}
+
+	engineURL, discoveredParams, err := c.resolveDiscoveredEndpoint(discovery.endpoint())
+	if err != nil {
+		return "", nil, err
+	}
+
+	parameters := copyStringMap(discoveredParams)
+	for k, v := range discovery.Parameters {
+		parameters[k] = v
+	}
+	for k, v := range discovery.QueryParameters {
+		parameters[k] = v
+	}
+	for k, v := range c.ConnectionParameters {
+		parameters[k] = v
+	}
+	if databaseName != "" {
+		parameters["database"] = databaseName
+	}
+	if engineName != "" {
+		parameters["engine"] = engineName
+	}
+
+	return engineURL, parameters, nil
+}
+
+func (c *ClientImplDiscovery) getDiscovery(ctx context.Context) (*discoveryResponse, error) {
+	discoveryURL := strings.TrimRight(c.ApiEndpoint, "/") + discoveryPath
+	resp := c.requestWithAuthRetry(ctx, http.MethodGet, discoveryURL, nil, "")
+	if resp.err != nil {
+		return nil, errorUtils.ConstructNestedError("error during discovery request", resp.err)
+	}
+	content, err := resp.Content()
+	if err != nil {
+		return nil, errorUtils.ConstructNestedError("error during reading discovery response", err)
+	}
+
+	var discovery discoveryResponse
+	if len(content) == 0 {
+		return nil, errors.New("empty discovery response")
+	}
+	if err := json.Unmarshal(content, &discovery); err != nil {
+		return nil, errorUtils.ConstructNestedError("error during unmarshalling discovery response", err)
+	}
+	return &discovery, nil
+}
+
+func (r *discoveryResponse) endpoint() string {
+	for _, endpoint := range []string{
+		r.EngineURL,
+		r.EngineUrl,
+		r.Endpoint,
+		r.QueryEndpoint,
+		r.QueryEndpointJS,
+		r.SQLURL,
+		r.SQLUrl,
+		r.SQLHTTPURL,
+	} {
+		if endpoint != "" {
+			return endpoint
+		}
+	}
+	return ""
+}
+
+func (c *ClientImplDiscovery) resolveDiscoveredEndpoint(discovered string) (string, map[string]string, error) {
+	if discovered == "" {
+		return "", nil, errors.New("discovery response does not contain an endpoint")
+	}
+
+	base, err := url.Parse(MakeCanonicalUrl(c.ApiEndpoint))
+	if err != nil {
+		return "", nil, err
+	}
+
+	endpointURL, err := parseEndpointRelativeToBase(discovered, base)
+	if err != nil {
+		return "", nil, err
+	}
+
+	parameters := make(map[string]string)
+	for key, values := range endpointURL.Query() {
+		if len(values) > 0 {
+			parameters[key] = values[0]
+		}
+	}
+	endpointURL.RawQuery = ""
+	return endpointURL.String(), parameters, nil
+}
+
+func parseEndpointRelativeToBase(endpoint string, base *url.URL) (*url.URL, error) {
+	if strings.HasPrefix(endpoint, "http://") || strings.HasPrefix(endpoint, "https://") {
+		return url.Parse(endpoint)
+	}
+	if strings.HasPrefix(endpoint, "/") {
+		return base.ResolveReference(&url.URL{Path: endpoint}), nil
+	}
+	return url.Parse(fmt.Sprintf("%s://%s", base.Scheme, endpoint))
+}
+
+func copyStringMap(original map[string]string) map[string]string {
+	result := make(map[string]string)
+	for k, v := range original {
+		result[k] = v
+	}
+	return result
+}

--- a/client/client_discovery_test.go
+++ b/client/client_discovery_test.go
@@ -1,0 +1,138 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/firebolt-db/firebolt-go-sdk/types"
+)
+
+func TestDiscoveryGetConnectionParameters(t *testing.T) {
+	var queryHit bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case discoveryPath:
+			_, _ = fmt.Fprintf(w, `{
+				"engine_url": "%s/query?from_discovery=true",
+				"query_parameters": {"timezone": "UTC", "database": "discovered_db"}
+			}`, r.Host)
+		case "/query":
+			queryHit = true
+			if r.URL.Query().Get("database") != "client_db" {
+				t.Errorf("database query parameter got %q want client_db", r.URL.Query().Get("database"))
+			}
+			if r.URL.Query().Get("engine") != "client_engine" {
+				t.Errorf("engine query parameter got %q want client_engine", r.URL.Query().Get("engine"))
+			}
+			if r.URL.Query().Get("timezone") != "UTC" {
+				t.Errorf("timezone query parameter got %q want UTC", r.URL.Query().Get("timezone"))
+			}
+			if r.URL.Query().Get("from_discovery") != "true" {
+				t.Errorf("from_discovery query parameter got %q want true", r.URL.Query().Get("from_discovery"))
+			}
+			if r.Header.Get("Authorization") != "" {
+				t.Errorf("discovery client should not send Authorization header, got %q", r.Header.Get("Authorization"))
+			}
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client, err := MakeClientDiscovery(&types.FireboltSettings{
+		DiscoveryEndpoint: server.URL,
+		SSLMode:           "none",
+		ConnectionParameters: map[string]string{
+			"database": "client_db",
+			"engine":   "client_engine",
+		},
+	})
+	if err != nil {
+		t.Fatalf("MakeClientDiscovery returned an error: %v", err)
+	}
+
+	engineURL, params, err := client.GetConnectionParameters(context.Background(), "", "")
+	if err != nil {
+		t.Fatalf("GetConnectionParameters returned an error: %v", err)
+	}
+	if engineURL != server.URL+"/query" {
+		t.Fatalf("engineURL got %q want %q", engineURL, server.URL+"/query")
+	}
+	if params["database"] != "client_db" || params["engine"] != "client_engine" || params["timezone"] != "UTC" || params["from_discovery"] != "true" {
+		t.Fatalf("unexpected params: %v", params)
+	}
+
+	_, err = client.Query(context.Background(), engineURL, "SELECT 1", params, ConnectionControl{})
+	if err != nil {
+		t.Fatalf("Query returned an error: %v", err)
+	}
+	if !queryHit {
+		t.Fatal("expected query endpoint to be called")
+	}
+}
+
+func TestDiscoveryEndpointAliases(t *testing.T) {
+	tests := []string{
+		`{"engineUrl": "%s/query"}`,
+		`{"endpoint": "%s/query"}`,
+		`{"query_endpoint": "%s/query"}`,
+		`{"queryEndpoint": "%s/query"}`,
+		`{"sql_url": "%s/query"}`,
+		`{"sqlUrl": "%s/query"}`,
+		`{"sql_http_url": "%s/query"}`,
+	}
+
+	for _, responseTemplate := range tests {
+		t.Run(responseTemplate, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != discoveryPath {
+					t.Errorf("unexpected path %s", r.URL.Path)
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				_, _ = fmt.Fprintf(w, responseTemplate, r.Host)
+			}))
+			defer server.Close()
+
+			client, err := MakeClientDiscovery(&types.FireboltSettings{DiscoveryEndpoint: server.URL, SSLMode: "none"})
+			if err != nil {
+				t.Fatalf("MakeClientDiscovery returned an error: %v", err)
+			}
+			engineURL, _, err := client.GetConnectionParameters(context.Background(), "", "")
+			if err != nil {
+				t.Fatalf("GetConnectionParameters returned an error: %v", err)
+			}
+			if engineURL != server.URL+"/query" {
+				t.Fatalf("engineURL got %q want %q", engineURL, server.URL+"/query")
+			}
+		})
+	}
+}
+
+func TestDiscoveryRelativeEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == discoveryPath {
+			_, _ = w.Write([]byte(`{"endpoint": "/query"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client, err := MakeClientDiscovery(&types.FireboltSettings{DiscoveryEndpoint: server.URL, SSLMode: "none"})
+	if err != nil {
+		t.Fatalf("MakeClientDiscovery returned an error: %v", err)
+	}
+	engineURL, _, err := client.GetConnectionParameters(context.Background(), "", "")
+	if err != nil {
+		t.Fatalf("GetConnectionParameters returned an error: %v", err)
+	}
+	if engineURL != server.URL+"/query" {
+		t.Fatalf("engineURL got %q want %q", engineURL, server.URL+"/query")
+	}
+}

--- a/client/client_integration_common_test.go
+++ b/client/client_integration_common_test.go
@@ -1,5 +1,5 @@
-//go:build integration || integration_v0 || integration_core
-// +build integration integration_v0 integration_core
+//go:build integration || integration_v0 || integration_core || integration_discovery
+// +build integration integration_v0 integration_core integration_discovery
 
 package client
 

--- a/client/client_integration_discovery_test.go
+++ b/client/client_integration_discovery_test.go
@@ -1,0 +1,37 @@
+//go:build integration_discovery
+// +build integration_discovery
+
+package client
+
+import (
+	"context"
+
+	"github.com/firebolt-db/firebolt-go-sdk/types"
+)
+
+var (
+	engineUrlMock string
+	databaseMock  string
+	clientMock    *ClientImplDiscovery
+)
+
+func init() {
+	databaseMock = "integration_test_db"
+	client, err := ClientFactory(&types.FireboltSettings{
+		Database:             databaseMock,
+		DiscoveryEndpoint:    "http://localhost:3473",
+		SSLMode:              "none",
+		NewVersion:           true,
+		ConnectionParameters: map[string]string{"database": databaseMock},
+	}, GetHostNameURL())
+	if err != nil {
+		panic(err)
+	}
+
+	clientMock = client.(*ClientImplDiscovery)
+	engineUrl, _, err := clientMock.GetConnectionParameters(context.Background(), "", databaseMock)
+	if err != nil {
+		panic(err)
+	}
+	engineUrlMock = engineUrl
+}

--- a/client/factory.go
+++ b/client/factory.go
@@ -10,6 +10,9 @@ func ClientFactory(settings *types.FireboltSettings, apiEndpoint string) (Client
 	userAgent := ConstructUserAgentString()
 
 	if settings.NewVersion {
+		if settings.DiscoveryEndpoint != "" {
+			return MakeClientDiscovery(settings)
+		}
 		if settings.Url != "" {
 			return MakeClientCore(settings)
 		}

--- a/client/http_client.go
+++ b/client/http_client.go
@@ -55,8 +55,31 @@ func NewHttpClient() *http.Client {
 // NewHttpClientWithTransport creates an *http.Client with the given
 // RoundTripper. If rt is nil, DefaultTransport() is used.
 func NewHttpClientWithTransport(rt http.RoundTripper) *http.Client {
+	return NewHttpClientWithTransportAndTLS(rt, false)
+}
+
+// NewHttpClientWithTransportAndTLS creates an *http.Client and, when
+// insecureSkipVerify is true, disables TLS certificate verification on
+// *http.Transport instances. Non-transport RoundTrippers are used as-is.
+func NewHttpClientWithTransportAndTLS(rt http.RoundTripper, insecureSkipVerify bool) *http.Client {
 	if rt == nil {
-		return NewHttpClient()
+		rt = DefaultTransport()
+	}
+	if insecureSkipVerify {
+		if t, ok := rt.(*http.Transport); ok {
+			t = t.Clone()
+			tlsConfig := t.TLSClientConfig
+			if tlsConfig == nil {
+				tlsConfig = &tls.Config{}
+			} else {
+				tlsConfig = tlsConfig.Clone()
+			}
+			tlsConfig.InsecureSkipVerify = true //nolint:gosec // ssl_mode=none explicitly opts out of certificate verification.
+			t.TLSClientConfig = tlsConfig
+			rt = t
+		} else {
+			logging.Infolog.Println("custom RoundTripper is not *http.Transport; skipping ssl_mode=none TLS configuration")
+		}
 	}
 	return &http.Client{Transport: rt}
 }
@@ -75,12 +98,26 @@ func NewHttpClientForLB(tlsServerName string) *http.Client {
 // the caller is responsible for TLS configuration in their custom
 // RoundTripper. If rt is nil, DefaultTransport() is used.
 func NewHttpClientForLBWithTransport(rt http.RoundTripper, tlsServerName string) *http.Client {
+	return NewHttpClientForLBWithTransportAndTLS(rt, tlsServerName, false)
+}
+
+func NewHttpClientForLBWithTransportAndTLS(rt http.RoundTripper, tlsServerName string, insecureSkipVerify bool) *http.Client {
 	if rt == nil {
 		rt = DefaultTransport()
 	}
-	if tlsServerName != "" {
+	if tlsServerName != "" || insecureSkipVerify {
 		if t, ok := rt.(*http.Transport); ok {
-			t.TLSClientConfig = &tls.Config{ServerName: tlsServerName}
+			t = t.Clone()
+			tlsConfig := t.TLSClientConfig
+			if tlsConfig == nil {
+				tlsConfig = &tls.Config{}
+			} else {
+				tlsConfig = tlsConfig.Clone()
+			}
+			tlsConfig.ServerName = tlsServerName
+			tlsConfig.InsecureSkipVerify = insecureSkipVerify //nolint:gosec // ssl_mode=none explicitly opts out of certificate verification.
+			t.TLSClientConfig = tlsConfig
+			rt = t
 		} else {
 			logging.Infolog.Printf("custom RoundTripper is not *http.Transport; skipping TLS ServerName override for %q", tlsServerName)
 		}

--- a/client/http_client_test.go
+++ b/client/http_client_test.go
@@ -2,6 +2,8 @@ package client
 
 import (
 	"context"
+	"crypto/tls"
+	"net/http"
 	"strings"
 	"testing"
 )
@@ -68,5 +70,24 @@ func TestDoHttpRequestMalformedURLWithPercent2(t *testing.T) {
 	errorMsg := resp.err.Error()
 	if !strings.Contains(errorMsg, "POST") {
 		t.Errorf("Expected error message to contain method 'POST', got: %s", errorMsg)
+	}
+}
+
+func TestNewHttpClientWithTransportAndTLSDoesNotMutateOriginal(t *testing.T) {
+	transport := &http.Transport{TLSClientConfig: &tls.Config{ServerName: "example.com"}}
+
+	client := NewHttpClientWithTransportAndTLS(transport, true)
+	configuredTransport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("expected client transport to be *http.Transport")
+	}
+	if configuredTransport == transport {
+		t.Fatal("expected transport to be cloned")
+	}
+	if !configuredTransport.TLSClientConfig.InsecureSkipVerify {
+		t.Fatal("expected InsecureSkipVerify to be enabled")
+	}
+	if transport.TLSClientConfig.InsecureSkipVerify {
+		t.Fatal("expected original transport to remain unchanged")
 	}
 }

--- a/connection_common_integration_test.go
+++ b/connection_common_integration_test.go
@@ -1,5 +1,5 @@
-//go:build integration || integration_v0 || integration_core
-// +build integration integration_v0 integration_core
+//go:build integration || integration_v0 || integration_core || integration_discovery
+// +build integration integration_v0 integration_core integration_discovery
 
 package fireboltgosdk
 

--- a/driver_common_integration_test.go
+++ b/driver_common_integration_test.go
@@ -1,5 +1,5 @@
-//go:build integration || integration_v0 || integration_core
-// +build integration integration_v0 integration_core
+//go:build integration || integration_v0 || integration_core || integration_discovery
+// +build integration integration_v0 integration_core integration_discovery
 
 package fireboltgosdk
 

--- a/driver_integration_discovery_test.go
+++ b/driver_integration_discovery_test.go
@@ -1,0 +1,39 @@
+//go:build integration_discovery
+// +build integration_discovery
+
+package fireboltgosdk
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+)
+
+var (
+	dsnMock           string
+	dsnNoDatabaseMock string
+	databaseMock      string
+)
+
+func init() {
+	databaseMock = "integration_test_db"
+	dsnMock = fmt.Sprintf("firebolt://localhost:3473?database=%s&ssl_mode=none", databaseMock)
+	dsnNoDatabaseMock = "firebolt://localhost:3473?ssl_mode=none"
+
+	conn, err := sql.Open("firebolt", dsnNoDatabaseMock)
+	if err != nil {
+		panic(fmt.Sprintf("failed to open discovery connection: %v", err))
+	}
+	defer conn.Close()
+	if _, err = conn.Exec(fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", databaseMock)); err != nil {
+		panic(fmt.Sprintf("failed to create database: %v", err))
+	}
+}
+
+func TestDriverDiscoveryExecStatement(t *testing.T) {
+	runTestDriverExecStatement(t, dsnMock)
+}
+
+func TestDriverDiscoveryOpenNoDatabase(t *testing.T) {
+	runTestDriverExecStatement(t, dsnNoDatabaseMock)
+}

--- a/dsn.go
+++ b/dsn.go
@@ -3,6 +3,7 @@ package fireboltgosdk
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"regexp"
 	"strings"
@@ -16,6 +17,8 @@ import (
 const dsnPattern = `^firebolt://(?:/(?P<database>\w+))?(?:\?(?P<parameters>[\w\.]+=[^=&]+(?:\&[\w\.]+=[^=&]+)*))?$`
 const dsnPatternV0 = `^firebolt://(?P<username>.*@?.*):(?P<password>.*)@(?P<database>\w+)(?:/(?P<engine>[^?]+))?(?:\?(?P<parameters>[\w\.]+=[^=&]+(?:\&[\w\.]+=[^=&]+)*))?$`
 const paramsPattern = `(?P<key>[\w\.]+)=(?P<value>[^=&]+)`
+const sslModeStrict = "strict"
+const sslModeNone = "none"
 
 // ParseDSNString parses a dsn in a format: firebolt://username:password@db_name[/engine_name][?account_name=organization]
 // returns a settings object where all parsed values are populated
@@ -30,6 +33,8 @@ func ParseDSNString(dsn string) (*types.FireboltSettings, error) {
 		return makeSettings(dsnMatch)
 	} else if dsnMatch := dsnExprV0.FindStringSubmatch(dsn); len(dsnMatch) > 0 {
 		return makeSettingsV0(dsnMatch)
+	} else if settings, ok, err := makeDiscoverySettings(dsn); ok {
+		return settings, err
 	} else {
 		return nil, errors.New("invalid connection string format")
 	}
@@ -75,6 +80,11 @@ func makeSettings(dsnMatch []string) (*types.FireboltSettings, error) {
 			result.ClientSecret = decodedValue
 		case "url":
 			result.Url = decodedValue
+		case "ssl_mode":
+			if decodedValue != sslModeStrict && decodedValue != sslModeNone {
+				return nil, fmt.Errorf("invalid ssl_mode value %q", decodedValue)
+			}
+			result.SSLMode = decodedValue
 		case "client_side_lb":
 			result.ClientSideLB = decodedValue == "true"
 		case "client_side_lb_dns_ttl":
@@ -88,6 +98,90 @@ func makeSettings(dsnMatch []string) (*types.FireboltSettings, error) {
 		}
 	}
 	return &result, nil
+}
+
+func makeDiscoverySettings(dsn string) (*types.FireboltSettings, bool, error) {
+	parsed, err := url.Parse(dsn)
+	if err != nil || parsed.Scheme != "firebolt" || parsed.Host == "" || parsed.User != nil {
+		return nil, false, nil
+	}
+
+	result := types.FireboltSettings{
+		NewVersion:           true,
+		ClientSideLB:         true,
+		DefaultQueryParams:   make(map[string]string),
+		ConnectionParameters: make(map[string]string),
+		SSLMode:              sslModeStrict,
+	}
+
+	query := parsed.Query()
+	if pathDatabase := strings.TrimPrefix(parsed.EscapedPath(), "/"); pathDatabase != "" {
+		database, err := url.PathUnescape(pathDatabase)
+		if err != nil {
+			return nil, true, fmt.Errorf("failed to URL decode database path: %w", err)
+		}
+		result.Database = database
+		result.ConnectionParameters["database"] = database
+	}
+
+	for key, values := range query {
+		if len(values) == 0 {
+			continue
+		}
+		value := values[0]
+		if strings.HasPrefix(key, "default_param.") {
+			paramKey := strings.TrimPrefix(key, "default_param.")
+			result.DefaultQueryParams[paramKey] = value
+			continue
+		}
+		if err := applyDiscoveryParameter(&result, key, value); err != nil {
+			return nil, true, err
+		}
+	}
+
+	result.DiscoveryEndpoint = buildDiscoveryEndpoint(parsed, result.SSLMode)
+	return &result, true, nil
+}
+
+func applyDiscoveryParameter(settings *types.FireboltSettings, key, value string) error {
+	switch key {
+	case "database":
+		settings.Database = value
+		settings.ConnectionParameters[key] = value
+	case "engine":
+		settings.EngineName = value
+		settings.ConnectionParameters[key] = value
+	case "ssl_mode":
+		if value != sslModeStrict && value != sslModeNone {
+			return fmt.Errorf("invalid ssl_mode value %q", value)
+		}
+		settings.SSLMode = value
+	case "client_side_lb":
+		settings.ClientSideLB = value == "true"
+	case "client_side_lb_dns_ttl":
+		d, err := time.ParseDuration(value)
+		if err != nil {
+			return fmt.Errorf("invalid client_side_lb_dns_ttl value %q: %w", value, err)
+		}
+		settings.DNSTTL = d
+	case "url":
+		return fmt.Errorf("url parameter is not supported for discovery DSNs")
+	default:
+		settings.ConnectionParameters[key] = value
+	}
+	return nil
+}
+
+func buildDiscoveryEndpoint(parsed *url.URL, sslMode string) string {
+	scheme := "https"
+	if sslMode == sslModeNone {
+		scheme = "http"
+	}
+	host := parsed.Host
+	if parsed.Port() != "" {
+		host = net.JoinHostPort(parsed.Hostname(), parsed.Port())
+	}
+	return (&url.URL{Scheme: scheme, Host: host}).String()
 }
 
 func makeSettingsV0(dsnMatch []string) (*types.FireboltSettings, error) {

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -104,7 +104,6 @@ func TestDSNHappyPath(t *testing.T) {
 func TestDSNFailed(t *testing.T) {
 	runDSNTestFail(t, "")
 	runDSNTestFail(t, "other_db://")
-	runDSNTestFail(t, "firebolt://db")      // another / is needed before a db
 	runDSNTestFail(t, "firebolt://?k=v")    // unknown parameter name
 	runDSNTestFail(t, "firebolt:///db?k=v") // unknown parameter name
 }

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -2,6 +2,7 @@ package fireboltgosdk
 
 import (
 	"net/url"
+	"reflect"
 	"testing"
 	"time"
 
@@ -33,6 +34,18 @@ func runDSNTest(t *testing.T, input string, expectedSettings types.FireboltSetti
 		t.Errorf("for client_secret got %s want %s", settings.ClientSecret, expectedSettings.ClientSecret)
 	}
 
+	if settings.Url != expectedSettings.Url {
+		t.Errorf("for Url got %s want %s", settings.Url, expectedSettings.Url)
+	}
+
+	if settings.DiscoveryEndpoint != expectedSettings.DiscoveryEndpoint {
+		t.Errorf("for DiscoveryEndpoint got %s want %s", settings.DiscoveryEndpoint, expectedSettings.DiscoveryEndpoint)
+	}
+
+	if settings.SSLMode != expectedSettings.SSLMode {
+		t.Errorf("for SSLMode got %s want %s", settings.SSLMode, expectedSettings.SSLMode)
+	}
+
 	if settings.Database != expectedSettings.Database {
 		t.Errorf("for Database got %s want %s", settings.Database, expectedSettings.Database)
 	}
@@ -57,6 +70,10 @@ func runDSNTest(t *testing.T, input string, expectedSettings types.FireboltSetti
 		if settings.DefaultQueryParams[k] != v {
 			t.Errorf("for DefaultQueryParams[%s] got %s want %s", k, settings.DefaultQueryParams[k], v)
 		}
+	}
+
+	if !reflect.DeepEqual(settings.ConnectionParameters, expectedSettings.ConnectionParameters) {
+		t.Errorf("for ConnectionParameters got %v want %v", settings.ConnectionParameters, expectedSettings.ConnectionParameters)
 	}
 }
 
@@ -172,6 +189,62 @@ func TestDSNCoreClientSideLBDNSTTL(t *testing.T) {
 func TestDSNCoreClientSideLBDNSTTLInvalid(t *testing.T) {
 	runDSNTestFail(t, "firebolt:///test_db?url=http://my-svc:8080&client_side_lb_dns_ttl=bogus")
 	runDSNTestFail(t, "firebolt:///test_db?url=http://my-svc:8080&client_side_lb_dns_ttl=")
+}
+
+func TestDSNCoreSSLMode(t *testing.T) {
+	runDSNTest(t, "firebolt:///test_db?url=https://localhost:443&ssl_mode=none",
+		types.FireboltSettings{Database: "test_db", Url: "https://localhost:443", SSLMode: "none", NewVersion: true, ClientSideLB: true})
+
+	runDSNTestFail(t, "firebolt:///test_db?url=https://localhost:443&ssl_mode=invalid")
+}
+
+func TestDSNDiscoveryHappyPath(t *testing.T) {
+	runDSNTest(t, "firebolt://localhost:3473?database=test_db&engine=test_eng&timezone=UTC&ssl_mode=none",
+		types.FireboltSettings{
+			Database:          "test_db",
+			EngineName:        "test_eng",
+			DiscoveryEndpoint: "http://localhost:3473",
+			SSLMode:           "none",
+			NewVersion:        true,
+			ClientSideLB:      true,
+			ConnectionParameters: map[string]string{
+				"database": "test_db",
+				"engine":   "test_eng",
+				"timezone": "UTC",
+			},
+		})
+
+	runDSNTest(t, "firebolt://firebolt.example.com/test_db?query_label=sdk",
+		types.FireboltSettings{
+			Database:          "test_db",
+			DiscoveryEndpoint: "https://firebolt.example.com",
+			SSLMode:           "strict",
+			NewVersion:        true,
+			ClientSideLB:      true,
+			ConnectionParameters: map[string]string{
+				"database":    "test_db",
+				"query_label": "sdk",
+			},
+		})
+}
+
+func TestDSNDiscoveryQueryDatabaseTakesPrecedence(t *testing.T) {
+	runDSNTest(t, "firebolt://localhost:3473/path_db?database=query_db&ssl_mode=none",
+		types.FireboltSettings{
+			Database:          "query_db",
+			DiscoveryEndpoint: "http://localhost:3473",
+			SSLMode:           "none",
+			NewVersion:        true,
+			ClientSideLB:      true,
+			ConnectionParameters: map[string]string{
+				"database": "query_db",
+			},
+		})
+}
+
+func TestDSNDiscoveryFailed(t *testing.T) {
+	runDSNTestFail(t, "firebolt://localhost:3473?ssl_mode=invalid")
+	runDSNTestFail(t, "firebolt://localhost:3473?url=http://localhost:3473")
 }
 
 func TestDSNWithDefaultParams(t *testing.T) {

--- a/types/firebolt_settings.go
+++ b/types/firebolt_settings.go
@@ -6,15 +6,18 @@ import (
 )
 
 type FireboltSettings struct {
-	ClientID           string
-	ClientSecret       string
-	Database           string
-	EngineName         string
-	AccountName        string
-	Url                string
-	NewVersion         bool
-	ClientSideLB       bool
-	DNSTTL             time.Duration
-	Transport          http.RoundTripper
-	DefaultQueryParams map[string]string
+	ClientID             string
+	ClientSecret         string
+	Database             string
+	EngineName           string
+	AccountName          string
+	Url                  string
+	DiscoveryEndpoint    string
+	SSLMode              string
+	NewVersion           bool
+	ClientSideLB         bool
+	DNSTTL               time.Duration
+	Transport            http.RoundTripper
+	DefaultQueryParams   map[string]string
+	ConnectionParameters map[string]string
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add host-based discovery DSN parsing for `firebolt://host[:port]` with normalized connection parameters.
- Add a discovery client that resolves `/.well-known/firebolt` endpoints and reuses the existing query/session machinery.
- Support `ssl_mode` for discovery and direct core connections.
- Add discovery unit tests and a get.firebolt.io-backed integration workflow/tag.

## Testing
- `go test ./...`
- `go test ./... -race -timeout=10s -v --tags=race`

## Notes
- The discovery integration workflow installs Firebolt with `bash <(curl -s https://get.firebolt.io/)` and runs `go test ./... -timeout=30m -v --tags=integration_discovery`.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [FB-1829](https://linear.app/firebolt-supreme/issue/FB-1829/support-new-firebolt-in-go-sdk)

<div><a href="https://cursor.com/agents/bc-9fdcf014-e849-452b-84f1-7be15f9929f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9fdcf014-e849-452b-84f1-7be15f9929f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

